### PR TITLE
Restricted attributes

### DIFF
--- a/src/finn/custom_op/general/im2col.py
+++ b/src/finn/custom_op/general/im2col.py
@@ -80,8 +80,8 @@ class Im2Col(CustomOp):
             "input_shape": ("s", True, ""),
             "pad_amount": ("i", False, 0),
             "pad_value": ("i", False, 0),
-            # depthwise: if != 0, infer ConvolutionInputGenerator with depthwise == 1
-            "depthwise": ("i", False, 0),
+            # depthwise: if 1, infer ConvolutionInputGenerator with depthwise == 1
+            "depthwise": ("i", False, 0, {0, 1}),
         }
 
     def make_shape_compatible_op(self, model):

--- a/src/finn/custom_op/general/multithreshold.py
+++ b/src/finn/custom_op/general/multithreshold.py
@@ -92,7 +92,7 @@ class MultiThreshold(CustomOp):
             "out_dtype": ("s", True, ""),
             "out_scale": ("f", False, 1.0),
             "out_bias": ("f", False, 0.0),
-            "data_layout": ("s", False, "NCHW"),
+            "data_layout": ("s", False, "NCHW", {"NCHW", "NHWC"}),
         }
 
     def make_shape_compatible_op(self, model):

--- a/src/finn/custom_op/general/quantavgpool2d.py
+++ b/src/finn/custom_op/general/quantavgpool2d.py
@@ -8,8 +8,8 @@ from finn.custom_op.general.maxpoolnhwc import compute_pool_output_dim
 
 
 class QuantAvgPool2d(CustomOp):
-    """Class that corresponds to the quantized average pooling
-    layer from brevitas"""
+    """CustomOp that corresponds to the quantized average pooling
+    layer from Brevitas"""
 
     def get_nodeattr_types(self):
         return {
@@ -18,9 +18,9 @@ class QuantAvgPool2d(CustomOp):
             "ibits": ("i", True, 1),
             "obits": ("i", True, 1),
             # determines if values are signed (set to "1") or unsigned ("0")
-            "signed": ("i", True, 0),
+            "signed": ("i", True, 0, {0, 1}),
             # data layout attribute can be set to "NCHW" or "NHWC"
-            "data_layout": ("s", False, "NCHW"),
+            "data_layout": ("s", False, "NCHW", {"NCHW", "NHWC"}),
         }
 
     def make_shape_compatible_op(self, model):


### PR DESCRIPTION
Introduce an (optional) specification for which set of values are allowed for attributes in `CustomOp`s. This is indicated by having a fourth member of the attribute definition tuple. If allowed values are specified, the existing/new value will be checked when the getter/setter for the attribute is invoked.

See https://github.com/Xilinx/finn-base/blob/69d624868eb5c97e81fd8d5cc927ec15f23e80f3/src/finn/custom_op/general/multithreshold.py#L95 as an example.