### PR TITLE
Allow dict as input to ApplyConfig

### DIFF
--- a/src/finn/transformation/general.py
+++ b/src/finn/transformation/general.py
@@ -283,7 +283,7 @@ class ApplyConfig(Transformation):
         if isinstance(self.config, dict):
             model_config = self.config
         else:
-            with open(self.config_file, "r") as f:
+            with open(self.config, "r") as f:
                 model_config = json.load(f)
 
         used_configurations = ["Defaults"]

--- a/src/finn/transformation/general.py
+++ b/src/finn/transformation/general.py
@@ -261,7 +261,7 @@ class ConvertDivToMul(Transformation):
 
 
 class ApplyConfig(Transformation):
-    """Applies node properties (attributes) from either a config dict or its JSON 
+    """Applies node properties (attributes) from either a config dict or its JSON
     representation given as a filename.
     The JSON file can specify default values for particular op_types, as well
     as values for nodes with particular names. Example dict::

--- a/src/finn/transformation/general.py
+++ b/src/finn/transformation/general.py
@@ -261,7 +261,8 @@ class ConvertDivToMul(Transformation):
 
 
 class ApplyConfig(Transformation):
-    """Applies node properties (attributes) from a JSON file with config dict.
+    """Applies node properties (attributes) from either a config dict or its JSON 
+    representation given as a filename.
     The JSON file can specify default values for particular op_types, as well
     as values for nodes with particular names. Example dict::
 

--- a/src/finn/transformation/general.py
+++ b/src/finn/transformation/general.py
@@ -274,14 +274,17 @@ class ApplyConfig(Transformation):
 
     """
 
-    def __init__(self, config_file):
+    def __init__(self, config):
         super().__init__()
-        self.config_file = config_file
+        self.config = config
 
     def apply(self, model):
 
-        with open(self.config_file, "r") as f:
-            model_config = json.load(f)
+        if isinstance(self.config, dict):
+            model_config = self.config
+        else:
+            with open(self.config_file, "r") as f:
+                model_config = json.load(f)
 
         used_configurations = ["Defaults"]
         missing_configurations = []


### PR DESCRIPTION
Makes ApplyConfig more convenient when applying generated configurations directly in code, without having to save to disk first.