### PR TITLE
Added timout to throughput_test_remote

### DIFF
--- a/src/finn/core/throughput_test.py
+++ b/src/finn/core/throughput_test.py
@@ -35,9 +35,10 @@ from finn.core.rtlsim_exec import rtlsim_exec
 from finn.util.basic import gen_finn_dt_tensor
 
 
-def throughput_test_remote(model, batchsize=1000):
+def throughput_test_remote(model, batchsize=1000, timeout=None):
     """Runs the throughput test for the given model remotely on the pynq board.
     The metadata properties related to the pynq board have to be set.
+    Additionally a timeout for the SSH communication can be set.
     Returns a dictionary with results of the throughput test. Returns None
     if the test fails."""
 
@@ -83,7 +84,7 @@ def throughput_test_remote(model, batchsize=1000):
     ).format(pynq_username, pynq_ip, pynq_port, pynq_target_dir, deployment_folder)
     bash_command = ["/bin/bash", "-c", cmd]
     process_throughput_test = subprocess.Popen(bash_command, stdout=subprocess.PIPE)
-    process_throughput_test.communicate()
+    process_throughput_test.communicate(timeout=timeout)
 
     # remove any pre-existing metrics file
     try:
@@ -101,7 +102,7 @@ def throughput_test_remote(model, batchsize=1000):
     )
     bash_command = ["/bin/bash", "-c", cmd]
     process_compile = subprocess.Popen(bash_command, stdout=subprocess.PIPE)
-    process_compile.communicate()
+    process_compile.communicate(timeout=timeout)
 
     try:
         with open("{}/nw_metrics.txt".format(deployment_dir), "r") as file:


### PR DESCRIPTION
Just a really small addition.

In some cases it may happen that the communication to the board hangs indefinitely during the throughput test. This can happen in particular when the clock setting is too high for the synthesized network. In this case the network runs incorrectly and it seems like the remote connection never returns.
For these cases the timeout can prevent a program, which uses FINN, form stalling.

Cheers,
Hendrik

