### PR TITLE
Added support for dilation value = 2 for 1D and 2D images/kernels

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,3 +8,4 @@ Contributors
 * Lucian Petrica (@quetric)
 * Tobias Alonso (@Tobi-Alonso)
 * Hendrik Borras (@HenniOVP)
+* Mirza Mrahorovic (@mmrahorovic)

--- a/src/finn/custom_op/general/im2col.py
+++ b/src/finn/custom_op/general/im2col.py
@@ -8,11 +8,18 @@ from finn.custom_op.base import CustomOp
 # adapted from A. Karpathy's CS231 im2col code
 # utilities to generate a patch matrix from a multichannel image
 # of shape (batches, channels, height, width)
+# note: the spatial dimensions can be set to 1 to indicate
+# a dummy dimension (e.g. 1D convs represented as 2D)
 
 
 def compute_conv_output_dim(ifm_dim, k, stride, pad=0):
     """Returns spatial output dimension size for convolution with given params."""
-    return int(((ifm_dim + 2 * pad - k) / stride) + 1)
+    if ifm_dim == 1:
+        # indicates dummy dimension, keep as-is
+        out_dim = 1
+    else:
+        out_dim = int(((ifm_dim + 2 * pad - k) / stride) + 1)
+    return out_dim
 
 
 def get_im2col_indices_nchw(
@@ -38,16 +45,45 @@ def get_im2col_indices_nchw(
 
 
 def im2col_indices_nchw(
-    x, field_height, field_width, padding=0, stride_y=1, stride_x=1, pad_val=0
+    x,
+    ifm_h,
+    ifm_w,
+    field_height,
+    field_width,
+    padding=0,
+    stride_y=1,
+    stride_x=1,
+    pad_val=0,
 ):
-    """Performs im2col on x with given field height and width, as well as values
-    for padding and stride size.
+    """Performs im2col on image (2D tensor, possibly with 1-length dummy dimensions) x with
+    given field height and width, as well as values for padding and stride size.
     Returns result of im2col."""
     # Zero-pad the input
     p = padding
-    x_padded = np.pad(
-        x, ((0, 0), (0, 0), (p, p), (p, p)), mode="constant", constant_values=pad_val
-    )
+
+    if ifm_h == 1:  # Shape of input image is: (1, C, 1, W)
+        x_padded = np.pad(
+            x,
+            ((0, 0), (0, 0), (0, 0), (p, p)),
+            mode="constant",
+            constant_values=pad_val,
+        )
+    elif ifm_w == 1:  # Shape of input image is: (1, C, H, 1)
+        x_padded = np.pad(
+            x,
+            ((0, 0), (0, 0), (p, p), (0, 0)),
+            mode="constant",
+            constant_values=pad_val,
+        )
+    elif ifm_h > 1 and ifm_w > 1:  # Shape of input image is: (1, C, H, W)
+        x_padded = np.pad(
+            x,
+            ((0, 0), (0, 0), (p, p), (p, p)),
+            mode="constant",
+            constant_values=pad_val,
+        )
+    else:
+        raise Exception("Unknown ifm_h/ifm_w combination in im2col_indices_nchw")
 
     k, i, j = get_im2col_indices_nchw(
         x.shape, field_height, field_width, padding, stride_y, stride_x
@@ -61,31 +97,41 @@ def im2col_indices_nchw(
 
 # ONNX i/o tensor shape assumptions for Im2Col:
 # input 0 is the input vector, shape (1, ih, iw, ifm)
-# output 0 is the output vector, shape (1, oh, ow, k*k*ifm)
+# output 0 is the output vector, shape (1, oh, ow, kh*kw*ifm)
 # where:
 # * ih, iw are the height and width of the input image
 # * oh, ow are the height and width of the output (lowered) image
 # * ifm is the number of input channels
-# * k is the convolutional kernel size
+# * kh, kw is the convolutional kernel size
 
 # note: for the innermost (dot product) dimension of k*k*ifm, we
 # assume an internal ordering (k, k, ifm)
+
+# note2: it's possible to set one of ih, iw to be 1 to indicate a
+# dummy dimension, e.g. for representing 1D convs as 2D. the corresponding
+# oh/ow and kh/kw will also be 1 in this case
 
 
 class Im2Col(CustomOp):
     def get_nodeattr_types(self):
         return {
+            # stride and shape of convolution kernel
             "stride": ("i", True, 1),
-            "kernel_size": ("i", True, 1),
+            "kernel_size": ("ints", True, []),
+            # input tensor shape
             "input_shape": ("s", True, ""),
+            # amount of padding to be inserted before/after each non-dummy spatial dim
             "pad_amount": ("i", False, 0),
+            # value of padding pixels to be inserted
             "pad_value": ("i", False, 0),
             # depthwise: if 1, infer ConvolutionInputGenerator with depthwise == 1
             "depthwise": ("i", False, 0, {0, 1}),
         }
 
     def make_shape_compatible_op(self, model):
-        k = self.get_nodeattr("kernel_size")
+        k = self.get_nodeattr("kernel_size")  # Assumption: Height x Width
+        k_h = k[0]
+        k_w = k[1]
         stride = self.get_nodeattr("stride")
         ishape = self.get_nodeattr("input_shape")
         pad = self.get_nodeattr("pad_amount")
@@ -100,12 +146,28 @@ class Im2Col(CustomOp):
         # extract all necessary information and determine output dimensions
         ifm_ch = ishape[-1]
         assert len(ishape) == 4, "Unexpected input shape for Im2Col"
-        assert ishape[1] == ishape[2], "Im2Col for non-square images unsupported"
-        ifm_dim = ishape[1]
-        ofm_dim = compute_conv_output_dim(ifm_dim, k, stride, pad)
+        ifm_dim_h = ishape[
+            1
+        ]  # NHWC (FINN always converts to NHWC during conv lowering)
+        ifm_dim_w = ishape[2]
+
+        # check that kernel tensor also respects any existing dummy dimensions
+        if ifm_dim_h == 1:
+            assert (
+                k_h == 1
+            ), "Unexpected kernel shape for input image of dimensions (N, 1, W, C)"
+        if ifm_dim_w == 1:
+            assert (
+                k_w == 1
+            ), "Unexpected kernel shape for input image of dimensions (N, H, 1, C)"
+
+        ofm_dim_h = compute_conv_output_dim(ifm_dim_h, k_h, stride, pad)
+        ofm_dim_w = compute_conv_output_dim(ifm_dim_w, k_w, stride, pad)
 
         # implement tensor with correct shape
-        values = np.random.randn(1, ofm_dim, ofm_dim, k * k * ifm_ch).astype(np.float32)
+        values = np.random.randn(1, ofm_dim_h, ofm_dim_w, k_h * k_w * ifm_ch).astype(
+            np.float32
+        )
         return helper.make_node(
             "Constant",
             inputs=[],
@@ -126,7 +188,10 @@ class Im2Col(CustomOp):
 
     def execute_node(self, context, graph):
         node = self.onnx_node
-        k = self.get_nodeattr("kernel_size")
+        k = self.get_nodeattr("kernel_size")  # Assumption: Height x Width
+        k_h = k[0]
+        k_w = k[1]
+
         stride = self.get_nodeattr("stride")
         pad = self.get_nodeattr("pad_amount")
         pad_val = self.get_nodeattr("pad_value")
@@ -140,18 +205,30 @@ class Im2Col(CustomOp):
             assert idt.allowed(pad_val), "Im2Col dtype must allow pad_val"
         # check that input is NHWC
         assert x.ndim == 4, "Unexpected number of input dims for Im2Col"
-        N, H, W, C = x.shape
-        assert H == W, "Unexpected input shape for Im2Col"
-        out_dim = compute_conv_output_dim(H, k, stride, pad)
+        n, h, w, c = x.shape
+
+        if h == 1:
+            assert (
+                k_h == 1
+            ), "Unexpected kernel shape for input image of dimensions (N, 1, W, C)"
+        if w == 1:
+            assert (
+                k_w == 1
+            ), "Unexpected kernel shape for input image of dimensions (N, H, 1, C)"
+
+        out_dim_H = compute_conv_output_dim(h, k_h, stride, pad)
+        out_dim_W = compute_conv_output_dim(w, k_w, stride, pad)
         # internally convert input to NCHW
         x = x.transpose(0, 3, 1, 2)
         # call NCHW im2col implementation
-        ret = im2col_indices_nchw(x, k, k, pad, stride, stride, pad_val=pad_val)
-        # result shape is (k*k*N, out_dim*out_dim), convert to NCHW
-        ret = ret.reshape(N, C, k, k, out_dim, out_dim)
+        ret = im2col_indices_nchw(
+            x, h, w, k_h, k_w, pad, stride, stride, pad_val=pad_val
+        )
+        # result shape is (k_H*k_W*N, out_dim_H*out_dim_W), convert to NCHW
+        ret = ret.reshape(n, c, k_h, k_w, out_dim_H, out_dim_W)
         # (N=0,C=1,kh=2,kw=3,H=4,W=5) -> (N=0,H=4,W=5,kh=2,kw=3,C=1)
         ret = ret.transpose(0, 4, 5, 2, 3, 1)
-        ret = ret.reshape(N, out_dim, out_dim, k * k * C)
+        ret = ret.reshape(n, out_dim_H, out_dim_W, k_h * k_w * c)
 
         # ret = ret.reshape(N, k * k * C, out_dim, out_dim)
         # convert output back to NHWC

--- a/src/finn/transformation/lower_convs_to_matmul.py
+++ b/src/finn/transformation/lower_convs_to_matmul.py
@@ -178,7 +178,7 @@ class LowerConvsToMatMul(Transformation):
                         [im2col_out],
                         domain="finn.custom_op.general",
                         stride=stride,
-                        kernel_size=k,
+                        kernel_size=[k, k],
                         pad_amount=pad,
                         input_shape="(1,{},{},{})".format(ifm_dim, ifm_dim, ifm_ch),
                         depthwise=dw,

--- a/src/finn/transformation/lower_convs_to_matmul.py
+++ b/src/finn/transformation/lower_convs_to_matmul.py
@@ -34,16 +34,21 @@ from finn.transformation.infer_shapes import InferShapes
 from finn.util.basic import get_by_name
 
 
-def _auto_pad_to_explicit_padding(autopad_str, idim, k, stride, n_dims):
-    pad_total = (stride - 1) * idim - stride + k
-    pad_half_small = int((pad_total / 2))
-    pad_half_large = pad_total - pad_half_small
+def _auto_pad_to_explicit_padding(
+    autopad_str, idim_h, idim_w, k_h, k_w, stride, n_dims
+):
+    pad_total_h = (stride - 1) * idim_h - stride + k_h
+    pad_total_w = (stride - 1) * idim_w - stride + k_w
+    pad_half_small_h = int((pad_total_h / 2))
+    pad_half_small_w = int((pad_total_w / 2))
+    pad_half_large_h = pad_total_h - pad_half_small_h
+    pad_half_large_w = pad_total_w - pad_half_small_w
     if autopad_str == "VALID":
         return [0 for i in range(2 * n_dims)]
     elif autopad_str == "SAME_UPPER":
-        return [pad_half_small, pad_half_large] * n_dims
+        return [pad_half_small_h, pad_half_small_w, pad_half_large_h, pad_half_large_w]
     elif autopad_str == "SAME_LOWER":
-        return [pad_half_large, pad_half_small] * n_dims
+        return [pad_half_large_h, pad_half_large_w, pad_half_small_h, pad_half_small_w]
     else:
         raise Exception("Unsupported auto_pad: " + autopad_str)
 
@@ -65,15 +70,19 @@ class LowerConvsToMatMul(Transformation):
                 idt = model.get_tensor_datatype(cnv_input)
                 odt = model.get_tensor_datatype(cnv_output)
                 # extract conv parameters
-                k = get_by_name(n.attribute, "kernel_shape").ints[-1]
+                k = get_by_name(n.attribute, "kernel_shape").ints
+                k_h = k[0]
+                k_w = k[1]
                 stride = get_by_name(n.attribute, "strides").ints[-1]
                 group = get_by_name(n.attribute, "group").i
                 weight_name = n.input[1]
                 W_conv = model.get_initializer(weight_name)
                 ifm_ch = model.get_tensor_shape(n.input[0])[1]  # assume NCHW
                 ofm_ch = model.get_tensor_shape(n.output[0])[1]  # assume NCHW
-                ifm_dim = model.get_tensor_shape(n.input[0])[-1]  # assume NCHW
-                ofm_dim = model.get_tensor_shape(n.output[0])[-1]  # assume NCHW
+                ifm_dim_h = model.get_tensor_shape(n.input[0])[2]  # assume NCHW
+                ifm_dim_w = model.get_tensor_shape(n.input[0])[3]
+                ofm_dim_h = model.get_tensor_shape(n.output[0])[2]  # assume NCHW
+                ofm_dim_w = model.get_tensor_shape(n.output[0])[3]
                 # handle both auto_pad and explicit padding
                 auto_pad = get_by_name(n.attribute, "auto_pad")
                 if auto_pad is not None:
@@ -85,34 +94,50 @@ class LowerConvsToMatMul(Transformation):
                     else:
                         pad = _auto_pad_to_explicit_padding(
                             auto_pad,
-                            ifm_dim,
-                            k,
+                            ifm_dim_h,
+                            ifm_dim_w,
+                            k_h,
+                            k_w,
                             stride,
                             len(model.get_tensor_shape(n.input[0])) - 2,
                         )
                 else:
                     # use specified padding
                     pad = get_by_name(n.attribute, "pads").ints
-                # ensure all pads are equal for now
-                assert (
-                    len(set(pad)) <= 1
-                ), "Only all-equal padding supported for now: " + str(pad)
-                pad = pad[-1]
+
+                # If len(pad) == 2, assume no padding for other dimension
+                if len(pad) == 2:  # only one dimension should be padded
+                    assert (
+                        ifm_dim_h == 1 or ifm_dim_w == 1
+                    ), "Padding is assumed to be 1D, image is 2D"
+                    if ifm_dim_h == 1:  # Assumption: dim H is not padded
+                        pad_2D = [0, 0, 0, 0]
+                        pad_2D[1] = pad[0]
+                        pad_2D[3] = pad[1]
+                    elif ifm_dim_w == 1:  # Assumption: dim W is not padded
+                        pad_2D = [0, 0, 0, 0]
+                        pad_2D[0] = pad[0]
+                        pad_2D[2] = pad[1]
+                    pad = pad_2D
 
                 # if depthwise conv create sparse matrix and variable "dw"
                 # to store as attribute in Im2Col that indicates that the created
                 # Im2Col node belongs to a depthwise convolution
                 dw = False
                 if group == ifm_ch and ofm_ch == ifm_ch:
-                    W_sparse = np.zeros((ofm_ch, ifm_ch, k, k))
+                    W_sparse = np.zeros(
+                        (ofm_ch, ifm_ch, k_h, k_w)
+                    )  # (OFM, IFM, k_H, k_W)
                     for ch in range(ifm_ch):
-                        W_sparse[ch][ch] = W_conv[ch][0]
+                        W_sparse[ch][ch] = W_conv[ch][
+                            0
+                        ]  # W_conv = [OFM, IFM, k_H, k_W]
                     W_conv = W_sparse.astype(np.float32)
                     # we need to store information of the
                     # sparsity of the weight matrix. For this
                     # we use the sparsity annotation of the
                     # weight tensor
-                    sparsity = {"dw": {"kernel_shape": k}}
+                    sparsity = {"dw": {"kernel_shape": k_h}}
                     model.set_tensor_sparsity(weight_name, sparsity)
                     # additionally create variable "dw" to store
                     # as attribute in Im2Col that indicates that the created
@@ -123,9 +148,9 @@ class LowerConvsToMatMul(Transformation):
                 # conv weights are [OFM][IFM][k][k]
                 # first convert to [OFM][k][k][IFM] (to remain compatible with
                 # finn-hlslib and how it does im2col/sliding window)
-                W_matmul = W_conv.transpose(0, 2, 3, 1)
+                W_matmul = W_conv.transpose(0, 2, 3, 1)  # W_conv = [OFM, IFM, k_H, k_W]
                 # reshape into [OFM][k*k*IFM] matrix
-                W_matmul = W_matmul.reshape(ofm_ch, ifm_ch * k * k)
+                W_matmul = W_matmul.reshape(ofm_ch, ifm_ch * k_h * k_w)
                 # transpose to get ONNX-compatible [k*k*IFM][OFM] matrix
                 W_matmul = W_matmul.T
                 model.set_initializer(weight_name, W_matmul)
@@ -134,21 +159,25 @@ class LowerConvsToMatMul(Transformation):
                 inp_trans_out = helper.make_tensor_value_info(
                     model.make_new_valueinfo_name(),
                     TensorProto.FLOAT,
-                    (1, ifm_dim, ifm_dim, ifm_ch),  # NHWC
+                    (1, ifm_dim_h, ifm_dim_w, ifm_ch),  # NHWC
                 )
                 graph.value_info.append(inp_trans_out)
                 inp_trans_out = inp_trans_out.name
                 model.set_tensor_datatype(inp_trans_out, idt)
 
                 need_im2col = True
-                if k == 1 and pad == 0 and stride == 1:
+                if all(p == 0 for p in pad):
+                    padding = 0
+
+                # k_h=k_w==1: pointwise convolution, thus no im2col needed
+                if k_h == 1 and k_w == 1 and padding == 0 and stride == 1:
                     need_im2col = False
 
                 if need_im2col:
                     im2col_out = helper.make_tensor_value_info(
                         model.make_new_valueinfo_name(),
                         TensorProto.FLOAT,
-                        (1, ofm_dim, ofm_dim, ifm_ch * k * k),
+                        (1, ofm_dim_h, ofm_dim_w, ifm_ch * k_h * k_w),
                     )
                     graph.value_info.append(im2col_out)
                     im2col_out = im2col_out.name
@@ -157,7 +186,7 @@ class LowerConvsToMatMul(Transformation):
                 matmul_out = helper.make_tensor_value_info(
                     model.make_new_valueinfo_name(),
                     TensorProto.FLOAT,
-                    (1, ofm_dim, ofm_dim, ofm_ch),
+                    (1, ofm_dim_h, ofm_dim_w, ofm_ch),
                 )
                 graph.value_info.append(matmul_out)
                 matmul_out = matmul_out.name
@@ -178,9 +207,9 @@ class LowerConvsToMatMul(Transformation):
                         [im2col_out],
                         domain="finn.custom_op.general",
                         stride=stride,
-                        kernel_size=[k, k],
+                        kernel_size=[k_h, k_w],
                         pad_amount=pad,
-                        input_shape="(1,{},{},{})".format(ifm_dim, ifm_dim, ifm_ch),
+                        input_shape="(1,{},{},{})".format(ifm_dim_h, ifm_dim_w, ifm_ch),
                         depthwise=dw,
                     )
 

--- a/tests/custom_op/test_im2col.py
+++ b/tests/custom_op/test_im2col.py
@@ -22,15 +22,18 @@ def check_two_dict_for_equality(dict1, dict2):
     return True
 
 
-def execution_im2col(x, idt, k, stride, ifm_ch, ifm_dim, pad_amt=0, pad_val=0):
-    ofm_dim = compute_conv_output_dim(ifm_dim, k, stride, pad_amt)
+def execution_im2col(
+    x, idt, k_h, k_w, stride, ifm_ch, ifm_dim_h, ifm_dim_w, pad_amt=0, pad_val=0
+):
+    ofm_dim_H = compute_conv_output_dim(ifm_dim_h, k_h, stride, pad_amt)
+    ofm_dim_W = compute_conv_output_dim(ifm_dim_w, k_w, stride, pad_amt)
 
     # set up onnx model
     inp = helper.make_tensor_value_info(
-        "inp", TensorProto.FLOAT, [1, ifm_dim, ifm_dim, ifm_ch]
+        "inp", TensorProto.FLOAT, [1, ifm_dim_h, ifm_dim_w, ifm_ch]
     )
     outp = helper.make_tensor_value_info(
-        "outp", TensorProto.FLOAT, [1, ofm_dim, ofm_dim, k * k * ifm_ch]
+        "outp", TensorProto.FLOAT, [1, ofm_dim_H, ofm_dim_W, k_h * k_w * ifm_ch]
     )
 
     Im2Col_node = helper.make_node(
@@ -39,10 +42,10 @@ def execution_im2col(x, idt, k, stride, ifm_ch, ifm_dim, pad_amt=0, pad_val=0):
         ["outp"],
         domain="finn.custom_op.general",
         stride=stride,
-        kernel_size=k,
+        kernel_size=[k_h, k_w],
         pad_amount=pad_amt,
         pad_value=pad_val,
-        input_shape="(1,{},{},{})".format(ifm_dim, ifm_dim, ifm_ch),
+        input_shape="(1,{},{},{})".format(ifm_dim_h, ifm_dim_w, ifm_ch),
     )
 
     graph = helper.make_graph(
@@ -56,7 +59,12 @@ def execution_im2col(x, idt, k, stride, ifm_ch, ifm_dim, pad_amt=0, pad_val=0):
 
     # test shape inference
     model.transform(InferShapes())
-    assert model.get_tensor_shape("outp") == [1, ofm_dim, ofm_dim, k * k * ifm_ch]
+    assert model.get_tensor_shape("outp") == [
+        1,
+        ofm_dim_H,
+        ofm_dim_W,
+        k_h * k_w * ifm_ch,
+    ]
 
     # test datatype inference
     assert model.get_tensor_datatype("outp") is DataType.FLOAT32
@@ -72,16 +80,34 @@ def execution_im2col(x, idt, k, stride, ifm_ch, ifm_dim, pad_amt=0, pad_val=0):
     return y_produced
 
 
+# Configurations tested:
+# case id     | 0       | 1    | 2    | 3    | 4    | 5    | 6    | 7    | 8    |
+# idt         | Bipolar | INT8 | INT8 | INT8 | INT8 | INT8 | INT8 | INT8 | INT8 |
+# ifm_dim_H   | 4       | 4    | 4    | 4    | 4    | 4    | 5    | 5    | 5    |
+# ifm_dim_W   | 4       | 4    | 4    | 5    | 5    | 5    | 1    | 1    | 1    |
+# ifm_ch      | 1       | 2    | 2    | 2    | 2    | 2    | 2    | 2    | 2    |
+# pad_amt     | 0       | 0    | 1    | 0    | 0    | 1    | 0    | 1    | 1    |
+# pad_val     | 0       | 0    | 0    | 0    | 0    | 0    | 0    | 0    | 0    |
+# k_H         | 2       | 2    | 2    | 2    | 3    | 3    | 3    | 3    | 3    |
+# k_W         | 2       | 2    | 2    | 2    | 2    | 2    | 1    | 1    | 1    |
+# stride      | 1       | 1    | 1    | 1    | 1    | 1    | 1    | 1    | 2    |
+
+
 def test_im2col():
+    case_id = 0
     # bipolar inputs with following im2col parameters
     idt = DataType.BIPOLAR
-    k = 2
+    k_h = 2
+    k_w = 2
     stride = 1
     ifm_ch = 1
-    ifm_dim = 4
+    ifm_dim_h = 4
+    ifm_dim_w = 4
     pad_amt = 0
     pad_val = 0
-    ofm_dim = compute_conv_output_dim(ifm_dim, k, stride, pad_amt)
+
+    ofm_dim_h = compute_conv_output_dim(ifm_dim_h, k_h, stride, pad_amt)
+    ofm_dim_w = compute_conv_output_dim(ifm_dim_w, k_w, stride, pad_amt)
 
     x = np.asarray(
         [
@@ -103,7 +129,7 @@ def test_im2col():
             1.0,
         ],
         dtype=np.float32,
-    ).reshape(1, ifm_dim, ifm_dim, ifm_ch)
+    ).reshape(1, ifm_dim_h, ifm_dim_w, ifm_ch)
 
     expected = np.asarray(
         [
@@ -145,19 +171,28 @@ def test_im2col():
             1.0,
         ],
         dtype=np.float32,
-    ).reshape(1, ofm_dim, ofm_dim, k * k * ifm_ch)
+    ).reshape(1, ofm_dim_h, ofm_dim_w, k_h * k_w * ifm_ch)
 
-    produced = execution_im2col(x, idt, k, stride, ifm_ch, ifm_dim, pad_amt, pad_val)
-    assert (produced == expected).all()
+    produced = execution_im2col(
+        x, idt, k_h, k_w, stride, ifm_ch, ifm_dim_h, ifm_dim_w, pad_amt, pad_val
+    )
+    assert (produced == expected).all(), "Test failed for case number {}".format(
+        case_id
+    )
 
+    case_id = 1
     idt = DataType.INT8
-    k = 2
+    k_h = 2
+    k_w = 2
     stride = 1
     ifm_ch = 2
-    ifm_dim = 4
+    ifm_dim_h = 4
+    ifm_dim_w = 4
     pad_amt = 0
     pad_val = 0
-    ofm_dim = compute_conv_output_dim(ifm_dim, k, stride, pad_amt)
+
+    ofm_dim_h = compute_conv_output_dim(ifm_dim_h, k_h, stride, pad_amt)
+    ofm_dim_w = compute_conv_output_dim(ifm_dim_w, k_w, stride, pad_amt)
 
     x = np.asarray(
         [
@@ -194,17 +229,26 @@ def test_im2col():
         dtype=np.float32,
     )
 
-    produced = execution_im2col(x, idt, k, stride, ifm_ch, ifm_dim, pad_amt, pad_val)
-    assert (produced == expected).all()
+    produced = execution_im2col(
+        x, idt, k_h, k_w, stride, ifm_ch, ifm_dim_h, ifm_dim_w, pad_amt, pad_val
+    )
+    assert (produced == expected).all(), "Test failed for case number {}".format(
+        case_id
+    )
 
+    case_id = 2
     idt = DataType.INT8
-    k = 2
+    k_h = 2
+    k_w = 2
     stride = 1
     ifm_ch = 2
-    ifm_dim = 4
+    ifm_dim_h = 4
+    ifm_dim_w = 4
     pad_amt = 1
     pad_val = 0
-    ofm_dim = compute_conv_output_dim(ifm_dim, k, stride, pad_amt)
+
+    ofm_dim_h = compute_conv_output_dim(ifm_dim_h, k_h, stride, pad_amt)
+    ofm_dim_w = compute_conv_output_dim(ifm_dim_w, k_w, stride, pad_amt)
 
     x = np.asarray(
         [
@@ -261,25 +305,319 @@ def test_im2col():
         dtype=np.float32,
     )
 
-    produced = execution_im2col(x, idt, k, stride, ifm_ch, ifm_dim, pad_amt, pad_val)
-    assert (produced == expected).all()
+    produced = execution_im2col(
+        x, idt, k_h, k_w, stride, ifm_ch, ifm_dim_h, ifm_dim_w, pad_amt, pad_val
+    )
+    assert (produced == expected).all(), "Test failed for case number {}".format(
+        case_id
+    )
+
+    case_id = 3
+    idt = DataType.INT8
+    k_h = 2
+    k_w = 2
+    stride = 1
+    ifm_ch = 2
+    ifm_dim_h = 4
+    ifm_dim_w = 5
+    pad_amt = 0
+    pad_val = 0
+
+    ofm_dim_h = compute_conv_output_dim(ifm_dim_h, k_h, stride, pad_amt)
+    ofm_dim_w = compute_conv_output_dim(ifm_dim_w, k_w, stride, pad_amt)
+
+    x = np.asarray(
+        [
+            [
+                [[1, -1], [2, -2], [3, -3], [4, -4], [5, -5]],
+                [[6, -6], [7, -7], [8, -8], [9, -9], [10, -10]],
+                [[11, -11], [12, -12], [13, -13], [14, -14], [15, -15]],
+                [[16, -16], [17, -17], [18, -18], [19, -19], [20, -20]],
+            ]
+        ],
+        dtype=np.float32,
+    )
+
+    expected = np.asarray(
+        [
+            [
+                [
+                    [1, -1, 2, -2, 6, -6, 7, -7],
+                    [2, -2, 3, -3, 7, -7, 8, -8],
+                    [3, -3, 4, -4, 8, -8, 9, -9],
+                    [4, -4, 5, -5, 9, -9, 10, -10],
+                ],
+                [
+                    [6, -6, 7, -7, 11, -11, 12, -12],
+                    [7, -7, 8, -8, 12, -12, 13, -13],
+                    [8, -8, 9, -9, 13, -13, 14, -14],
+                    [9, -9, 10, -10, 14, -14, 15, -15],
+                ],
+                [
+                    [11, -11, 12, -12, 16, -16, 17, -17],
+                    [12, -12, 13, -13, 17, -17, 18, -18],
+                    [13, -13, 14, -14, 18, -18, 19, -19],
+                    [14, -14, 15, -15, 19, -19, 20, -20],
+                ],
+            ]
+        ],
+        dtype=np.float32,
+    )
+
+    produced = execution_im2col(
+        x, idt, k_h, k_w, stride, ifm_ch, ifm_dim_h, ifm_dim_w, pad_amt, pad_val
+    )
+    assert (produced == expected).all(), "Test failed for case number {}".format(
+        case_id
+    )
+
+    case_id = 4
+    idt = DataType.INT8
+    k_h = 3
+    k_w = 2
+    stride = 1
+    ifm_ch = 2
+    ifm_dim_h = 4
+    ifm_dim_w = 5
+    pad_amt = 0
+    pad_val = 0
+
+    ofm_dim_h = compute_conv_output_dim(ifm_dim_h, k_h, stride, pad_amt)
+    ofm_dim_w = compute_conv_output_dim(ifm_dim_w, k_w, stride, pad_amt)
+
+    x = np.asarray(
+        [
+            [
+                [[1, -1], [2, -2], [3, -3], [4, -4], [5, -5]],
+                [[6, -6], [7, -7], [8, -8], [9, -9], [10, -10]],
+                [[11, -11], [12, -12], [13, -13], [14, -14], [15, -15]],
+                [[16, -16], [17, -17], [18, -18], [19, -19], [20, -20]],
+            ]
+        ],
+        dtype=np.float32,
+    )
+
+    expected = np.asarray(
+        [
+            [
+                [
+                    [1, -1, 2, -2, 6, -6, 7, -7, 11, -11, 12, -12],
+                    [2, -2, 3, -3, 7, -7, 8, -8, 12, -12, 13, -13],
+                    [3, -3, 4, -4, 8, -8, 9, -9, 13, -13, 14, -14],
+                    [4, -4, 5, -5, 9, -9, 10, -10, 14, -14, 15, -15],
+                ],
+                [
+                    [6, -6, 7, -7, 11, -11, 12, -12, 16, -16, 17, -17],
+                    [7, -7, 8, -8, 12, -12, 13, -13, 17, -17, 18, -18],
+                    [8, -8, 9, -9, 13, -13, 14, -14, 18, -18, 19, -19],
+                    [9, -9, 10, -10, 14, -14, 15, -15, 19, -19, 20, -20],
+                ],
+            ]
+        ],
+        dtype=np.float32,
+    )
+
+    produced = execution_im2col(
+        x, idt, k_h, k_w, stride, ifm_ch, ifm_dim_h, ifm_dim_w, pad_amt, pad_val
+    )
+    assert (produced == expected).all(), "Test failed for case number {}".format(
+        case_id
+    )
+
+    case_id = 5
+    idt = DataType.INT8
+    k_h = 3
+    k_w = 2
+    stride = 1
+    ifm_ch = 2
+    ifm_dim_h = 4
+    ifm_dim_w = 5
+    pad_amt = 1
+    pad_val = 0
+
+    ofm_dim_h = compute_conv_output_dim(ifm_dim_h, k_h, stride, pad_amt)
+    ofm_dim_w = compute_conv_output_dim(ifm_dim_w, k_w, stride, pad_amt)
+
+    x = np.asarray(
+        [
+            [
+                [[1, -1], [2, -2], [3, -3], [4, -4], [5, -5]],
+                [[6, -6], [7, -7], [8, -8], [9, -9], [10, -10]],
+                [[11, -11], [12, -12], [13, -13], [14, -14], [15, -15]],
+                [[16, -16], [17, -17], [18, -18], [19, -19], [20, -20]],
+            ]
+        ],
+        dtype=np.float32,
+    )
+
+    expected = np.asarray(
+        [
+            [
+                [
+                    [0, 0, 0, 0, 0, 0, 1, -1, 0, 0, 6, -6],
+                    [0, 0, 0, 0, 1, -1, 2, -2, 6, -6, 7, -7],
+                    [0, 0, 0, 0, 2, -2, 3, -3, 7, -7, 8, -8],
+                    [0, 0, 0, 0, 3, -3, 4, -4, 8, -8, 9, -9],
+                    [0, 0, 0, 0, 4, -4, 5, -5, 9, -9, 10, -10],
+                    [0, 0, 0, 0, 5, -5, 0, 0, 10, -10, 0, 0],
+                ],
+                [
+                    [0, 0, 1, -1, 0, 0, 6, -6, 0, 0, 11, -11],
+                    [1, -1, 2, -2, 6, -6, 7, -7, 11, -11, 12, -12],
+                    [2, -2, 3, -3, 7, -7, 8, -8, 12, -12, 13, -13],
+                    [3, -3, 4, -4, 8, -8, 9, -9, 13, -13, 14, -14],
+                    [4, -4, 5, -5, 9, -9, 10, -10, 14, -14, 15, -15],
+                    [5, -5, 0, 0, 10, -10, 0, 0, 15, -15, 0, 0],
+                ],
+                [
+                    [0, 0, 6, -6, 0, 0, 11, -11, 0, 0, 16, -16],
+                    [6, -6, 7, -7, 11, -11, 12, -12, 16, -16, 17, -17],
+                    [7, -7, 8, -8, 12, -12, 13, -13, 17, -17, 18, -18],
+                    [8, -8, 9, -9, 13, -13, 14, -14, 18, -18, 19, -19],
+                    [9, -9, 10, -10, 14, -14, 15, -15, 19, -19, 20, -20],
+                    [10, -10, 0, 0, 15, -15, 0, 0, 20, -20, 0, 0],
+                ],
+                [
+                    [0, 0, 11, -11, 0, 0, 16, -16, 0, 0, 0, 0],
+                    [11, -11, 12, -12, 16, -16, 17, -17, 0, 0, 0, 0],
+                    [12, -12, 13, -13, 17, -17, 18, -18, 0, 0, 0, 0],
+                    [13, -13, 14, -14, 18, -18, 19, -19, 0, 0, 0, 0],
+                    [14, -14, 15, -15, 19, -19, 20, -20, 0, 0, 0, 0],
+                    [15, -15, 0, 0, 20, -20, 0, 0, 0, 0, 0, 0],
+                ],
+            ]
+        ],
+        dtype=np.float32,
+    )
+
+    produced = execution_im2col(
+        x, idt, k_h, k_w, stride, ifm_ch, ifm_dim_h, ifm_dim_w, pad_amt, pad_val
+    )
+    assert (produced == expected).all(), "Test failed for case number {}".format(
+        case_id
+    )
+
+    case_id = 6
+    idt = DataType.INT8
+    k_h = 3
+    k_w = 1
+    stride = 1
+    ifm_ch = 2
+    ifm_dim_h = 5
+    ifm_dim_w = 1
+    pad_amt = 0
+    pad_val = 0
+
+    ofm_dim_h = compute_conv_output_dim(ifm_dim_h, k_h, stride, pad_amt)
+    ofm_dim_w = compute_conv_output_dim(ifm_dim_w, k_w, stride, pad_amt)
+
+    x = np.asarray(
+        [[[[1, -1]], [[2, -2]], [[3, -3]], [[4, -4]], [[5, -5]]]],
+        dtype=np.float32,
+    )
+
+    expected = np.asarray(
+        [[[[1, -1, 2, -2, 3, -3]], [[2, -2, 3, -3, 4, -4]], [[3, -3, 4, -4, 5, -5]]]],
+        dtype=np.float32,
+    )
+
+    produced = execution_im2col(
+        x, idt, k_h, k_w, stride, ifm_ch, ifm_dim_h, ifm_dim_w, pad_amt, pad_val
+    )
+    assert (produced == expected).all(), "Test failed for case number {}".format(
+        case_id
+    )
+
+    case_id = 7
+    idt = DataType.INT8
+    k_h = 3
+    k_w = 1
+    stride = 1
+    ifm_ch = 2
+    ifm_dim_h = 5
+    ifm_dim_w = 1
+    pad_amt = 1
+    pad_val = 0
+
+    ofm_dim_h = compute_conv_output_dim(ifm_dim_h, k_h, stride, pad_amt)
+    ofm_dim_w = compute_conv_output_dim(ifm_dim_w, k_w, stride, pad_amt)
+
+    x = np.asarray(
+        [[[[1, -1]], [[2, -2]], [[3, -3]], [[4, -4]], [[5, -5]]]],
+        dtype=np.float32,
+    )
+
+    expected = np.asarray(
+        [
+            [
+                [[0, 0, 1, -1, 2, -2]],
+                [[1, -1, 2, -2, 3, -3]],
+                [[2, -2, 3, -3, 4, -4]],
+                [[3, -3, 4, -4, 5, -5]],
+                [[4, -4, 5, -5, 0, 0]],
+            ]
+        ],
+        dtype=np.float32,
+    )
+
+    produced = execution_im2col(
+        x, idt, k_h, k_w, stride, ifm_ch, ifm_dim_h, ifm_dim_w, pad_amt, pad_val
+    )
+    assert (produced == expected).all(), "Test failed for case number {}".format(
+        case_id
+    )
+
+    case_id = 8
+    idt = DataType.INT8
+    k_h = 3
+    k_w = 1
+    stride = 2
+    ifm_ch = 2
+    ifm_dim_h = 5
+    ifm_dim_w = 1
+    pad_amt = 1
+    pad_val = 0
+
+    ofm_dim_h = compute_conv_output_dim(ifm_dim_h, k_h, stride, pad_amt)
+    ofm_dim_w = compute_conv_output_dim(ifm_dim_w, k_w, stride, pad_amt)
+
+    x = np.asarray(
+        [[[[1, -1]], [[2, -2]], [[3, -3]], [[4, -4]], [[5, -5]]]],
+        dtype=np.float32,
+    )
+
+    expected = np.asarray(
+        [[[[0, 0, 1, -1, 2, -2]], [[2, -2, 3, -3, 4, -4]], [[4, -4, 5, -5, 0, 0]]]],
+        dtype=np.float32,
+    )
+
+    produced = execution_im2col(
+        x, idt, k_h, k_w, stride, ifm_ch, ifm_dim_h, ifm_dim_w, pad_amt, pad_val
+    )
+    assert (produced == expected).all(), "Test failed for case number {}".format(
+        case_id
+    )
 
 
 def test_im2col_infer_shapes():
-
     idt = DataType.BIPOLAR
-    k = 2
+    k_h = 2
+    k_w = 2
     stride = 1
     ifm_ch = 1
-    ifm_dim = 4
-    ofm_dim = int(((ifm_dim - k) / stride) + 1)
+    ifm_dim_h = 4
+    ifm_dim_w = 4
+    pad_amt = 0  # default
+
+    ofm_dim_h = compute_conv_output_dim(ifm_dim_h, k_h, stride, pad_amt)
+    ofm_dim_w = compute_conv_output_dim(ifm_dim_w, k_w, stride, pad_amt)
 
     # set up onnx model
     inp = helper.make_tensor_value_info(
-        "inp", TensorProto.FLOAT, [1, ifm_dim, ifm_dim, ifm_ch]
+        "inp", TensorProto.FLOAT, [1, ifm_dim_h, ifm_dim_w, ifm_ch]
     )
     outp = helper.make_tensor_value_info(
-        "outp", TensorProto.FLOAT, [1, ofm_dim, ofm_dim, k * k * ifm_ch]
+        "outp", TensorProto.FLOAT, [1, ofm_dim_h, ofm_dim_w, k_h * k_w * ifm_ch]
     )
 
     abs_node = helper.make_node("Abs", inputs=["inp"], outputs=["abs"])
@@ -290,8 +628,8 @@ def test_im2col_infer_shapes():
         ["im2col"],
         domain="finn.custom_op.general",
         stride=stride,
-        kernel_size=k,
-        input_shape="(1,{},{},{})".format(ifm_dim, ifm_dim, ifm_ch),
+        kernel_size=[k_h, k_w],
+        input_shape="(1,{},{},{})".format(ifm_dim_h, ifm_dim_w, ifm_ch),
     )
 
     abs1_node = helper.make_node("Abs", inputs=["im2col"], outputs=["outp"])
@@ -303,10 +641,12 @@ def test_im2col_infer_shapes():
         outputs=[outp],
         value_info=[
             helper.make_tensor_value_info(
-                "abs", TensorProto.FLOAT, [1, ifm_dim, ifm_dim, ifm_ch]
+                "abs", TensorProto.FLOAT, [1, ifm_dim_h, ifm_dim_w, ifm_ch]
             ),
             helper.make_tensor_value_info(
-                "im2col", TensorProto.FLOAT, [1, ofm_dim, ofm_dim, k * k * ifm_ch]
+                "im2col",
+                TensorProto.FLOAT,
+                [1, ofm_dim_h, ofm_dim_w, k_h * k_w * ifm_ch],
             ),
         ],
     )
@@ -318,4 +658,9 @@ def test_im2col_infer_shapes():
 
     # test shape inference
     model.transform(InferShapes())
-    assert model.get_tensor_shape("im2col") == [1, ofm_dim, ofm_dim, k * k * ifm_ch]
+    assert model.get_tensor_shape("im2col") == [
+        1,
+        ofm_dim_h,
+        ofm_dim_w,
+        k_h * k_w * ifm_ch,
+    ]

--- a/tests/custom_op/test_im2col.py
+++ b/tests/custom_op/test_im2col.py
@@ -23,20 +23,22 @@ def check_two_dict_for_equality(dict1, dict2):
 
 
 def execution_im2col(
-    x, idt, k_h, k_w, stride, ifm_ch, ifm_dim_h, ifm_dim_w, pad_amt=0, pad_val=0
+    x, idt, k_h, k_w, stride, ifm_ch, ifm_dim_h, ifm_dim_w, pad_amt, pad_val=0
 ):
-    ofm_dim_H = compute_conv_output_dim(ifm_dim_h, k_h, stride, pad_amt)
-    ofm_dim_W = compute_conv_output_dim(ifm_dim_w, k_w, stride, pad_amt)
+    pad_amt_h = pad_amt[0] + pad_amt[2]
+    pad_amt_w = pad_amt[1] + pad_amt[3]
+    ofm_dim_h = compute_conv_output_dim(ifm_dim_h, k_h, stride, pad_amt_h)
+    ofm_dim_w = compute_conv_output_dim(ifm_dim_w, k_w, stride, pad_amt_w)
 
     # set up onnx model
     inp = helper.make_tensor_value_info(
         "inp", TensorProto.FLOAT, [1, ifm_dim_h, ifm_dim_w, ifm_ch]
     )
     outp = helper.make_tensor_value_info(
-        "outp", TensorProto.FLOAT, [1, ofm_dim_H, ofm_dim_W, k_h * k_w * ifm_ch]
+        "outp", TensorProto.FLOAT, [1, ofm_dim_h, ofm_dim_w, k_h * k_w * ifm_ch]
     )
 
-    Im2Col_node = helper.make_node(
+    im2col_node = helper.make_node(
         "Im2Col",
         ["inp"],
         ["outp"],
@@ -49,7 +51,7 @@ def execution_im2col(
     )
 
     graph = helper.make_graph(
-        nodes=[Im2Col_node], name="im2col_graph", inputs=[inp], outputs=[outp]
+        nodes=[im2col_node], name="im2col_graph", inputs=[inp], outputs=[outp]
     )
 
     model = helper.make_model(graph, producer_name="im2col-model")
@@ -61,8 +63,8 @@ def execution_im2col(
     model.transform(InferShapes())
     assert model.get_tensor_shape("outp") == [
         1,
-        ofm_dim_H,
-        ofm_dim_W,
+        ofm_dim_h,
+        ofm_dim_w,
         k_h * k_w * ifm_ch,
     ]
 
@@ -103,11 +105,13 @@ def test_im2col():
     ifm_ch = 1
     ifm_dim_h = 4
     ifm_dim_w = 4
-    pad_amt = 0
+    pad_amt = [0, 0, 0, 0]
+    pad_amt_h = pad_amt[0] + pad_amt[2]
+    pad_amt_w = pad_amt[1] + pad_amt[3]
     pad_val = 0
 
-    ofm_dim_h = compute_conv_output_dim(ifm_dim_h, k_h, stride, pad_amt)
-    ofm_dim_w = compute_conv_output_dim(ifm_dim_w, k_w, stride, pad_amt)
+    ofm_dim_h = compute_conv_output_dim(ifm_dim_h, k_h, stride, pad_amt_h)
+    ofm_dim_w = compute_conv_output_dim(ifm_dim_w, k_w, stride, pad_amt_w)
 
     x = np.asarray(
         [
@@ -188,11 +192,8 @@ def test_im2col():
     ifm_ch = 2
     ifm_dim_h = 4
     ifm_dim_w = 4
-    pad_amt = 0
+    pad_amt = [0, 0, 0, 0]
     pad_val = 0
-
-    ofm_dim_h = compute_conv_output_dim(ifm_dim_h, k_h, stride, pad_amt)
-    ofm_dim_w = compute_conv_output_dim(ifm_dim_w, k_w, stride, pad_amt)
 
     x = np.asarray(
         [
@@ -244,11 +245,8 @@ def test_im2col():
     ifm_ch = 2
     ifm_dim_h = 4
     ifm_dim_w = 4
-    pad_amt = 1
+    pad_amt = [1, 1, 1, 1]
     pad_val = 0
-
-    ofm_dim_h = compute_conv_output_dim(ifm_dim_h, k_h, stride, pad_amt)
-    ofm_dim_w = compute_conv_output_dim(ifm_dim_w, k_w, stride, pad_amt)
 
     x = np.asarray(
         [
@@ -320,11 +318,8 @@ def test_im2col():
     ifm_ch = 2
     ifm_dim_h = 4
     ifm_dim_w = 5
-    pad_amt = 0
+    pad_amt = [0, 0, 0, 0]
     pad_val = 0
-
-    ofm_dim_h = compute_conv_output_dim(ifm_dim_h, k_h, stride, pad_amt)
-    ofm_dim_w = compute_conv_output_dim(ifm_dim_w, k_w, stride, pad_amt)
 
     x = np.asarray(
         [
@@ -379,11 +374,8 @@ def test_im2col():
     ifm_ch = 2
     ifm_dim_h = 4
     ifm_dim_w = 5
-    pad_amt = 0
+    pad_amt = [0, 0, 0, 0]
     pad_val = 0
-
-    ofm_dim_h = compute_conv_output_dim(ifm_dim_h, k_h, stride, pad_amt)
-    ofm_dim_w = compute_conv_output_dim(ifm_dim_w, k_w, stride, pad_amt)
 
     x = np.asarray(
         [
@@ -432,11 +424,8 @@ def test_im2col():
     ifm_ch = 2
     ifm_dim_h = 4
     ifm_dim_w = 5
-    pad_amt = 1
+    pad_amt = [1, 1, 1, 1]
     pad_val = 0
-
-    ofm_dim_h = compute_conv_output_dim(ifm_dim_h, k_h, stride, pad_amt)
-    ofm_dim_w = compute_conv_output_dim(ifm_dim_w, k_w, stride, pad_amt)
 
     x = np.asarray(
         [
@@ -505,11 +494,8 @@ def test_im2col():
     ifm_ch = 2
     ifm_dim_h = 5
     ifm_dim_w = 1
-    pad_amt = 0
+    pad_amt = [0, 0, 0, 0]
     pad_val = 0
-
-    ofm_dim_h = compute_conv_output_dim(ifm_dim_h, k_h, stride, pad_amt)
-    ofm_dim_w = compute_conv_output_dim(ifm_dim_w, k_w, stride, pad_amt)
 
     x = np.asarray(
         [[[[1, -1]], [[2, -2]], [[3, -3]], [[4, -4]], [[5, -5]]]],
@@ -536,11 +522,8 @@ def test_im2col():
     ifm_ch = 2
     ifm_dim_h = 5
     ifm_dim_w = 1
-    pad_amt = 1
+    pad_amt = [1, 0, 1, 0]
     pad_val = 0
-
-    ofm_dim_h = compute_conv_output_dim(ifm_dim_h, k_h, stride, pad_amt)
-    ofm_dim_w = compute_conv_output_dim(ifm_dim_w, k_w, stride, pad_amt)
 
     x = np.asarray(
         [[[[1, -1]], [[2, -2]], [[3, -3]], [[4, -4]], [[5, -5]]]],
@@ -575,11 +558,8 @@ def test_im2col():
     ifm_ch = 2
     ifm_dim_h = 5
     ifm_dim_w = 1
-    pad_amt = 1
+    pad_amt = [1, 0, 1, 0]
     pad_val = 0
-
-    ofm_dim_h = compute_conv_output_dim(ifm_dim_h, k_h, stride, pad_amt)
-    ofm_dim_w = compute_conv_output_dim(ifm_dim_w, k_w, stride, pad_amt)
 
     x = np.asarray(
         [[[[1, -1]], [[2, -2]], [[3, -3]], [[4, -4]], [[5, -5]]]],
@@ -607,10 +587,12 @@ def test_im2col_infer_shapes():
     ifm_ch = 1
     ifm_dim_h = 4
     ifm_dim_w = 4
-    pad_amt = 0  # default
+    pad_amt = [0, 0, 0, 0]  # default
+    pad_amt_h = pad_amt[0] + pad_amt[2]
+    pad_amt_w = pad_amt[1] + pad_amt[3]
 
-    ofm_dim_h = compute_conv_output_dim(ifm_dim_h, k_h, stride, pad_amt)
-    ofm_dim_w = compute_conv_output_dim(ifm_dim_w, k_w, stride, pad_amt)
+    ofm_dim_h = compute_conv_output_dim(ifm_dim_h, k_h, stride, pad_amt_h)
+    ofm_dim_w = compute_conv_output_dim(ifm_dim_w, k_w, stride, pad_amt_w)
 
     # set up onnx model
     inp = helper.make_tensor_value_info(

--- a/tests/transformation/test_conv_lowering.py
+++ b/tests/transformation/test_conv_lowering.py
@@ -72,40 +72,66 @@ def test_conv_lowering_convmnist():
 # input datatype
 @pytest.mark.parametrize("idt", [DataType.INT2, DataType.INT4])
 # kernel size
-@pytest.mark.parametrize("k", [2, 4])
+@pytest.mark.parametrize("k_h", [2])
+@pytest.mark.parametrize("k_w", [2])
 # input dimension
-@pytest.mark.parametrize("ifm_dim", [4, 6])
+@pytest.mark.parametrize("ifm_dim_h", [4])
+@pytest.mark.parametrize("ifm_dim_w", [4])
 # input channels
-@pytest.mark.parametrize("ifm_ch", [2, 3])
+@pytest.mark.parametrize("ifm_ch", [2])
 # stride
 @pytest.mark.parametrize("stride", [1, 2])
-# padding
-@pytest.mark.parametrize("padding", [[0, 0, 0, 0], [1, 1, 1, 1]])
-def test_depthwise_conv_lowering(idt, k, ifm_dim, ifm_ch, stride, padding):
-
+# padding. Padding is applied to dimensions H and W as: [H_begin, W_begin, H_end, W_end]
+@pytest.mark.parametrize(
+    "padding",
+    [
+        [0, 0, 0, 0],
+        [0, 0, 0, 1],
+        [0, 0, 1, 0],
+        [0, 0, 1, 1],
+        [0, 1, 0, 0],
+        [0, 1, 0, 1],
+        [0, 1, 1, 0],
+        [0, 1, 1, 1],
+        [1, 0, 0, 0],
+        [1, 0, 0, 1],
+        [1, 0, 1, 0],
+        [1, 0, 1, 1],
+        [1, 1, 0, 0],
+        [1, 1, 0, 1],
+        [1, 1, 1, 0],
+        [1, 1, 1, 1],
+    ],
+)
+def test_non_equal_padding(
+    idt, k_h, k_w, ifm_dim_h, ifm_dim_w, ifm_ch, stride, padding
+):
     wdt = idt
     odt = DataType.INT32
     ofm_ch = ifm_ch
-    ofm_dim = compute_conv_output_dim(ifm_dim, k, stride, pad=padding[0])
+    pad_h = padding[0] + padding[2]
+    pad_w = padding[1] + padding[3]
+    ofm_dim_h = compute_conv_output_dim(ifm_dim_h, k_h, stride, pad_h)
+    ofm_dim_w = compute_conv_output_dim(ifm_dim_w, k_w, stride, pad_w)
 
     # set up onnx model
     inp = oh.make_tensor_value_info(
-        "inp", TensorProto.FLOAT, [1, ifm_ch, ifm_dim, ifm_dim]
+        "inp", TensorProto.FLOAT, [1, ifm_ch, ifm_dim_h, ifm_dim_w]
     )
     outp = oh.make_tensor_value_info(
-        "outp", TensorProto.FLOAT, [1, ofm_ch, ofm_dim, ofm_dim]
+        "outp", TensorProto.FLOAT, [1, ofm_ch, ofm_dim_h, ofm_dim_w]
     )
 
-    W = oh.make_tensor_value_info("W", TensorProto.FLOAT, [ofm_ch, 1, k, k])
+    W = oh.make_tensor_value_info("W", TensorProto.FLOAT, [ofm_ch, ifm_ch, k_h, k_w])
 
     dw_cnv = oh.make_node(
         "Conv",
         inputs=["inp", "W"],
         outputs=["outp"],
-        kernel_shape=[k, k],
+        kernel_shape=[k_h, k_w],
         pads=padding,
         strides=[stride, stride],
-        group=ifm_ch,
+        group=1,
     )
     graph = oh.make_graph(
         nodes=[dw_cnv],
@@ -120,11 +146,11 @@ def test_depthwise_conv_lowering(idt, k, ifm_dim, ifm_ch, stride, padding):
     model.set_tensor_datatype("inp", idt)
     model.set_tensor_datatype("outp", odt)
     model.set_tensor_datatype("W", wdt)
-    w_tensor = gen_finn_dt_tensor(wdt, [ofm_ch, 1, k, k])
+    w_tensor = gen_finn_dt_tensor(wdt, [ofm_ch, ifm_ch, k_h, k_w])
     model.set_initializer("W", w_tensor)
     model = model.transform(InferShapes())
 
-    input_tensor = gen_finn_dt_tensor(idt, [1, ifm_ch, ifm_dim, ifm_dim])
+    input_tensor = gen_finn_dt_tensor(idt, [1, ifm_ch, ifm_dim_h, ifm_dim_w])
     input_dict = {"inp": input_tensor}
     output_dict = oxe.execute_onnx(model, input_dict)
     expected = output_dict["outp"]
@@ -134,23 +160,125 @@ def test_depthwise_conv_lowering(idt, k, ifm_dim, ifm_ch, stride, padding):
     produced = output_dict["outp"]
     assert (produced == expected).all()
 
-    # check if created nodes have attributes that indicate depthwise conv
-    assert model.get_tensor_sparsity("W") is not None
-    im2col_node = getCustomOp(model.graph.node[1])
-    assert im2col_node.get_nodeattr("depthwise") == 1
+
+# input datatype
+@pytest.mark.parametrize("idt", [DataType.INT2, DataType.INT4])
+# kernel size
+@pytest.mark.parametrize("k_h", [2, 4])
+@pytest.mark.parametrize("k_w", [2, 4, 1])
+# input dimension
+@pytest.mark.parametrize("ifm_dim_h", [4, 6])
+@pytest.mark.parametrize("ifm_dim_w", [4, 6, 1])
+# input channels
+@pytest.mark.parametrize("ifm_ch", [2, 3])
+# stride
+@pytest.mark.parametrize("stride", [1, 2])
+# padding
+@pytest.mark.parametrize("padding", [[0, 0, 0, 0], [1, 1, 1, 1]])
+# depthwise or channelwise
+@pytest.mark.parametrize("dw", [True, False])
+def test_dws_reg_conv_lowering(
+    idt, k_h, k_w, ifm_dim_h, ifm_dim_w, ifm_ch, stride, padding, dw
+):
+    if k_h > ifm_dim_h:
+        pytest.skip("Kernel height must be smaller than image height")
+    if k_w > ifm_dim_w:
+        pytest.skip("Kernel width must be smaller than image height")
+    # Ensure the right padding parameters are set
+    if ifm_dim_h == 1:
+        padding[0] = 0
+        padding[2] = 0
+    if ifm_dim_w == 1:
+        padding[1] = 0
+        padding[3] = 0
+
+    wdt = idt
+    odt = DataType.INT32
+    ofm_ch = ifm_ch
+    pad_h = padding[0] + padding[2]
+    pad_w = padding[1] + padding[3]
+
+    ofm_dim_h = compute_conv_output_dim(ifm_dim_h, k_h, stride, pad_h)
+    ofm_dim_w = compute_conv_output_dim(ifm_dim_w, k_w, stride, pad_w)
+
+    # set up onnx model
+    inp = oh.make_tensor_value_info(
+        "inp", TensorProto.FLOAT, [1, ifm_ch, ifm_dim_h, ifm_dim_w]
+    )
+    outp = oh.make_tensor_value_info(
+        "outp", TensorProto.FLOAT, [1, ofm_ch, ofm_dim_h, ofm_dim_w]
+    )
+
+    if dw is True:
+        W = oh.make_tensor_value_info("W", TensorProto.FLOAT, [ofm_ch, 1, k_h, k_w])
+        group = ifm_ch
+    else:
+        W = oh.make_tensor_value_info(
+            "W", TensorProto.FLOAT, [ofm_ch, ifm_ch, k_h, k_w]
+        )
+        group = 1
+
+    dw_cnv = oh.make_node(
+        "Conv",
+        inputs=["inp", "W"],
+        outputs=["outp"],
+        kernel_shape=[k_h, k_w],
+        pads=padding,
+        strides=[stride, stride],
+        group=group,
+    )
+    graph = oh.make_graph(
+        nodes=[dw_cnv],
+        name="dw_cnv_graph",
+        inputs=[inp],
+        outputs=[outp],
+        value_info=[W],
+    )
+
+    model = oh.make_model(graph, producer_name="test_dws_reg_cnv-model")
+    model = ModelWrapper(model)
+    model.set_tensor_datatype("inp", idt)
+    model.set_tensor_datatype("outp", odt)
+    model.set_tensor_datatype("W", wdt)
+
+    if dw is True:
+        w_tensor = gen_finn_dt_tensor(wdt, [ofm_ch, 1, k_h, k_w])
+    else:
+        w_tensor = gen_finn_dt_tensor(wdt, [ofm_ch, ifm_ch, k_h, k_w])
+
+    model.set_initializer("W", w_tensor)
+    model = model.transform(InferShapes())
+
+    input_tensor = gen_finn_dt_tensor(idt, [1, ifm_ch, ifm_dim_h, ifm_dim_w])
+    input_dict = {"inp": input_tensor}
+    output_dict = oxe.execute_onnx(model, input_dict)
+    expected = output_dict["outp"]
+
+    model = model.transform(LowerConvsToMatMul())
+    output_dict = oxe.execute_onnx(model, input_dict)
+    produced = output_dict["outp"]
+    assert (produced == expected).all()
+
+    if dw is True:
+        # check if created nodes have attributes that indicate depthwise conv
+        assert model.get_tensor_sparsity("W") is not None
+        im2col_node = getCustomOp(model.graph.node[1])
+        assert im2col_node.get_nodeattr("depthwise") == 1
 
 
 def test_conv_lowering_conv_1x1():
 
     np.random.seed(0)
 
-    in_feature_dim = 7
+    in_feature_dim_h = 7
+    in_feature_dim_w = 7
     in_chn = 3
     kernel_size = 1
-    out_feature_dim = in_feature_dim
+    out_feature_dim_h = in_feature_dim_h
+    out_feature_dim_w = in_feature_dim_w
 
-    input_shape = [1, in_chn, in_feature_dim, in_feature_dim]
-    output_shape = [1, in_chn, out_feature_dim, out_feature_dim]
+    input_shape = [1, in_chn, in_feature_dim_h, in_feature_dim_w]
+    output_shape = [1, in_chn, out_feature_dim_h, out_feature_dim_w]
 
     conv_param_shape = [in_chn, in_chn, kernel_size, kernel_size]
 

--- a/tests/transformation/test_general_transformation.py
+++ b/tests/transformation/test_general_transformation.py
@@ -138,12 +138,12 @@ def test_apply_config():
     model = model.transform(GiveUniqueNodeNames())
     # set up a config in a dict, then dump it to JSON
     config = {}
-    config["Defaults"] = {"kernel_size": [3, ["Im2Col"]]}
-    config["Im2Col_0"] = {"kernel_size": 7}
+    config["Defaults"] = {"kernel_size": [[3], ["Im2Col"]]}
+    config["Im2Col_0"] = {"kernel_size": [7]}
     with open("config.json", "w") as f:
         json.dump(config, f, indent=4)
     model = model.transform(ApplyConfig("config.json"))
     # check model
-    assert getCustomOp(model.graph.node[2]).get_nodeattr("kernel_size") == 7
-    assert getCustomOp(model.graph.node[9]).get_nodeattr("kernel_size") == 3
+    assert getCustomOp(model.graph.node[2]).get_nodeattr("kernel_size") == [7]
+    assert getCustomOp(model.graph.node[9]).get_nodeattr("kernel_size") == [3]
     os.remove("config.json")


### PR DESCRIPTION
[im2col] added support for dilations = 2 for 2D and 1D images. Dilation value must be equal along each axis.
[test_im2col] added several test cases in case dilations = 2 (a.o. cases where image and kernel are 2D and 1D, with and without padding, and with stride = 2).
[lower_convs_to_matmul] added support for dilation value. Dilation value must be equal along each axis.
[test_conv_lowering] added test case for dilations = 2 for 2D and 1D images and kernels, with and without padding, and with stride = 2.

This pull request (PR) contains the changes from PR #16.