### PR TITLE
Changes for supporting non-equal dilation

### DIFF
--- a/src/finn/transformation/change_3d_tensors_to_4d.py
+++ b/src/finn/transformation/change_3d_tensors_to_4d.py
@@ -169,7 +169,7 @@ class Change3DTo4DTensors(Transformation):
                 strides = get_by_name(n.attribute, "strides", "name").ints
                 if len(dilations) == 1:  # we must add another dimension to it
                     dilations.append(
-                        dilations[0]
+                        1
                     )  # only equal dilation value along each spatial axis is supported
                 if len(kernel_shape) == 1:  # we must add another dimension to it
                     kernel_shape.append(1)

--- a/src/finn/transformation/lower_convs_to_matmul.py
+++ b/src/finn/transformation/lower_convs_to_matmul.py
@@ -85,12 +85,8 @@ class LowerConvsToMatMul(Transformation):
                 dilation_attr = get_by_name(n.attribute, "dilations")
                 if dilation_attr is not None:
                     dilation = dilation_attr.ints
-                    assert (
-                        len(set(dilation)) <= 1
-                    ), "Only equal dilation value along each spatial axis is supported"
-                    dilation = dilation[0]
                 else:
-                    dilation = 1  # default value
+                    dilation = [1, 1]  # default value
                 # handle both auto_pad and explicit padding
                 auto_pad = get_by_name(n.attribute, "auto_pad")
                 if auto_pad is not None:
@@ -137,7 +133,7 @@ class LowerConvsToMatMul(Transformation):
                     # sparsity of the weight matrix. For this
                     # we use the sparsity annotation of the
                     # weight tensor
-                    sparsity = {"dw": {"kernel_shape": k_h}}
+                    sparsity = {"dw": {"kernel_shape": [k_h, k_w]}}
                     model.set_tensor_sparsity(weight_name, sparsity)
                     # additionally create variable "dw" to store
                     # as attribute in Im2Col that indicates that the created

--- a/tests/core/test_modelwrapper.py
+++ b/tests/core/test_modelwrapper.py
@@ -68,7 +68,7 @@ def test_modelwrapper():
     assert model.get_tensor_layout(first_conv_iname) == inp_layout
     inp_sparsity = model.get_tensor_sparsity(first_conv_iname)
     assert inp_sparsity is None
-    inp_sparsity = {"dw": {"kernel_shape": 3}}
+    inp_sparsity = {"dw": {"kernel_shape": [3, 3]}}
     model.set_tensor_sparsity(first_conv_iname, inp_sparsity)
     assert model.get_tensor_sparsity(first_conv_iname) == inp_sparsity
 

--- a/tests/transformation/test_conv_lowering.py
+++ b/tests/transformation/test_conv_lowering.py
@@ -95,10 +95,8 @@ def test_dws_reg_conv_lowering(
     if k_w > ifm_dim_w:
         pytest.skip("Kernel width must be smaller than image height")
     # Ensure the right padding parameters are set
-    if ifm_dim_h == 1:
-        padding[0] = 0
-        padding[2] = 0
     if ifm_dim_w == 1:
+        dilations[1] = 1
         padding[1] = 0
         padding[3] = 0
 
@@ -122,7 +120,7 @@ def test_dws_reg_conv_lowering(
         k_w,
         stride_w,
         pad_w,
-        dilations[0],
+        dilations[1],
     )
 
     # set up onnx model

--- a/tests/transformation/test_general_transformation.py
+++ b/tests/transformation/test_general_transformation.py
@@ -138,12 +138,12 @@ def test_apply_config():
     model = model.transform(GiveUniqueNodeNames())
     # set up a config in a dict, then dump it to JSON
     config = {}
-    config["Defaults"] = {"kernel_size": [[3], ["Im2Col"]]}
-    config["Im2Col_0"] = {"kernel_size": [7]}
+    config["Defaults"] = {"kernel_size": [[3, 3], ["Im2Col"]]}
+    config["Im2Col_0"] = {"kernel_size": [7, 7]}
     with open("config.json", "w") as f:
         json.dump(config, f, indent=4)
     model = model.transform(ApplyConfig("config.json"))
     # check model
-    assert getCustomOp(model.graph.node[2]).get_nodeattr("kernel_size") == [7]
-    assert getCustomOp(model.graph.node[9]).get_nodeattr("kernel_size") == [3]
+    assert getCustomOp(model.graph.node[2]).get_nodeattr("kernel_size") == [7, 7]
+    assert getCustomOp(model.graph.node[9]).get_nodeattr("kernel_size") == [3, 3]
     os.remove("config.json")

--- a/tests/transformation/test_merge_onnx_models.py
+++ b/tests/transformation/test_merge_onnx_models.py
@@ -81,7 +81,7 @@ def test_merge_onnx_models():
     model2.set_initializer("a1", a1_value)
     # set a dummy sparsity annotation to check if it gets correctly transferred
     # to the merged model
-    sparsity = {"dw": {"kernel_shape": 0}}
+    sparsity = {"dw": {"kernel_shape": [0, 0]}}
     model2.set_tensor_sparsity("a1", sparsity)
     model2 = model2.transform(InferShapes())
     model2 = model2.transform(InferDataTypes())


### PR DESCRIPTION
[im2col, lower_convs_to_matmul, change_3d_tensors_to_4d]: added support for non-equal dilation value along (H, W) dimensions. Also changed the tensor sparsity annotation from integer to list of integers. This is needed for non-square image support for the InferVVAU transformation.

[test_im2col, test_conv_lowering]: added test cases for non-equal dilation configurations.

[test_modelwrapper, test_general_transformation, test_merge_onnx_models]: changed tensor sparsity annotation for consistency (list of integers instead of integer).