### PR TITLE
Verilator: force inlining, disable common warnings

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,36 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,16 +1,11 @@
 # This workflow will upload a Python Package using Twine when a release is created
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 name: Upload Python Package
 
 on:
   release:
-    types: [published]
+    types: [created]
 
 jobs:
   deploy:
@@ -26,11 +21,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install build
-    - name: Build package
-      run: python -m build
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      run: |
+        python setup.py sdist
+        twine upload dist/*

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,3 +10,4 @@ Contributors
 * Hendrik Borras (@HenniOVP)
 * Mirza Mrahorovic (@mmrahorovic)
 * Felix Paul Jentzsch (@felixpj)
+* Jon Ander Lezeta (@jalezeta)

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -2,10 +2,11 @@
 Contributors
 ============
 
-* Yaman Umuroglu <yamanu@xilinx.com> (maintainer)
-* Sambhav Jain <sambhavj@xilinx.com> (maintainer)
+* Yaman Umuroglu (@maltanar) (maintainer)
+* Sambhav Jain (@sjain-stanford)
 * Jakoba Petri-Koenig (@auphelia)
 * Lucian Petrica (@quetric)
 * Tobias Alonso (@Tobi-Alonso)
 * Hendrik Borras (@HenniOVP)
 * Mirza Mrahorovic (@mmrahorovic)
+* Felix Paul Jentzsch (@felixpj)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## <img src=https://raw.githubusercontent.com/Xilinx/finn/master/docs/img/finn-logo.png width=128/> Core Components for Quantized Neural Network Inference
+## <img src=https://raw.githubusercontent.com/Xilinx/finn/github-pages/docs/img/finn-logo.png width=128/> Core Components for Quantized Neural Network Inference
 
 [![Gitter](https://badges.gitter.im/xilinx-finn/community.svg)](https://gitter.im/xilinx-finn/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![ReadTheDocs](https://readthedocs.org/projects/finn-base/badge/?version=latest&style=plastic)](http://finn-base.readthedocs.io/)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -73,7 +73,7 @@ RUN python -mpip install --upgrade pip && \
     rm requirements.txt
 
 # Install custom fork of pyverilator
-RUN pip install git+https://github.com/maltanar/pyverilator.git#egg=pyverilator
+RUN pip install git+https://github.com/maltanar/pyverilator.git@0c3eb9343500fc1352a02c020a736c8c2db47e8e
 
 # Install pytest-xdist (not in requirements, only for faster testing in Docker)
 RUN pip install pytest-xdist==2.0.0

--- a/src/finn/transformation/change_3d_tensors_to_4d.py
+++ b/src/finn/transformation/change_3d_tensors_to_4d.py
@@ -56,6 +56,12 @@ def _find_invalid_nodes(model):
         "Transpose",
         "LogSoftmax",
         "ArgMax",
+        "Div",
+        "TopK",
+        "MatMul",
+        "Flatten",
+        "Reshape",
+        "MaxPool",
     ]
     invalid_nodes = []
     for n in model.graph.node:
@@ -96,7 +102,7 @@ class Change3DTo4DTensors(Transformation):
         model = model.transform(RemoveUnusedTensors())
 
         # This list contains all nodes with initializers that need to be converted
-        nodes_with_initializers = ["Mul", "Conv", "Add"]
+        nodes_with_initializers = ["Mul", "Conv", "Add", "Div", "Reshape"]
         # Obtain a list of initializer names (used to filter out only value infos)
         initializers_names = [x.name for x in model.graph.initializer]
 
@@ -118,8 +124,7 @@ class Change3DTo4DTensors(Transformation):
                 if x.name not in initializers_names
             },
         }
-        # Extract only initializers from Conv, Mul and Add nodes (which are the
-        # only ones relevant for conversion)
+        # Extract only initializers from nodes that are relevant for conversion
         all_tensors = {
             **all_tensors,
             **{
@@ -143,10 +148,11 @@ class Change3DTo4DTensors(Transformation):
         tensors_reduced_dimension = []
         for n in model.graph.node:
             node_op_type = n.op_type
+            input_shape = model.get_tensor_shape(n.input[0])
             # Find tensors that are the output of nodes that reduce the dimension
             if node_op_type == "ArgMax":
                 keep_dims = get_by_name(n.attribute, "keepdims", "name").i
-                if keep_dims == 0:
+                if len(input_shape) == 3 and keep_dims == 0:
                     node_out = n.output
                     for n_o in node_out:
                         tensors_reduced_dimension.append(n_o)
@@ -158,10 +164,10 @@ class Change3DTo4DTensors(Transformation):
                     len(perm) == 3
                 ):  # Meaning that the transpose operation was on a 3D tensor
                     perm.append(3)  # append 4th dimension
-            elif node_op_type == "ArgMax" or node_op_type == "LogSoftMax":
+            elif node_op_type in ["ArgMax", "LogSoftMax", "TopK", "Flatten"]:
                 axis = get_by_name(n.attribute, "axis", "name")
-                if axis.i == -1:
-                    axis.i = 2  # argmax is now on the second-to-last axis
+                if len(input_shape) == 3 and axis.i < 0:
+                    axis.i = 3 + axis.i  # count dimensions from the front
             elif node_op_type == "Conv":
                 dilations = get_by_name(n.attribute, "dilations", "name").ints
                 kernel_shape = get_by_name(n.attribute, "kernel_shape", "name").ints
@@ -171,6 +177,19 @@ class Change3DTo4DTensors(Transformation):
                     dilations.append(
                         1
                     )  # only equal dilation value along each spatial axis is supported
+                if len(kernel_shape) == 1:  # we must add another dimension to it
+                    kernel_shape.append(1)
+                if (
+                    len(pads) == 2
+                ):  # pads = [x1_begin, x1_end] --> [x1_begin, x2_begin, x1_end, x2_end]
+                    pads.insert(1, 0)
+                    pads.append(0)
+                if len(strides) == 1:  # strides = [stride_h, stride_w]
+                    strides.append(1)
+            elif node_op_type == "MaxPool":
+                kernel_shape = get_by_name(n.attribute, "kernel_shape", "name").ints
+                pads = get_by_name(n.attribute, "pads", "name").ints
+                strides = get_by_name(n.attribute, "strides", "name").ints
                 if len(kernel_shape) == 1:  # we must add another dimension to it
                     kernel_shape.append(1)
                 if (

--- a/src/finn/util/basic.py
+++ b/src/finn/util/basic.py
@@ -44,6 +44,7 @@ pynq_part_map["Pynq-Z1"] = "xc7z020clg400-1"
 pynq_part_map["Pynq-Z2"] = "xc7z020clg400-1"
 pynq_part_map["ZCU102"] = "xczu9eg-ffvb1156-2-e"
 pynq_part_map["ZCU104"] = "xczu7ev-ffvc1156-2-e"
+pynq_part_map["ZCU111"] = "xczu28dr-ffvg1517-2-e"
 
 # native AXI HP port width (in bits) for PYNQ boards
 pynq_native_port_width = dict()
@@ -52,6 +53,7 @@ pynq_native_port_width["Pynq-Z2"] = 64
 pynq_native_port_width["Ultra96"] = 128
 pynq_native_port_width["ZCU102"] = 128
 pynq_native_port_width["ZCU104"] = 128
+pynq_native_port_width["ZCU111"] = 128
 
 # Alveo device and platform mappings
 alveo_part_map = dict()

--- a/src/finn/util/pyverilator.py
+++ b/src/finn/util/pyverilator.py
@@ -141,12 +141,20 @@ def rtlsim_multi_io(sim, io_dict, num_out_values, trace_file="", sname="_V_V_"):
     return total_cycle_count
 
 
-def pyverilate_stitched_ip(model, read_internal_signals=True):
+def pyverilate_stitched_ip(
+    model, read_internal_signals=True, disable_common_warnings=True
+):
     """Given a model with stitched IP, return a PyVerilator sim object.
-    If read_internal_signals is True, it will be possible to examine the
-    internal (not only port) signals of the Verilog module, but this may
-    slow down compilation and emulation.
     Trace depth is also controllable, see get_rtlsim_trace_depth()
+
+    :param read_internal_signals  If set, it will be possible to examine the
+        internal (not only port) signals of the Verilog module, but this may
+        slow down compilation and emulation.
+
+    :param disable_common_warnings If set, disable the set of warnings that
+        Vivado-HLS-generated Verilog typically triggers in Verilator
+        (which can be very verbose otherwise)
+
     """
     if PyVerilator is None:
         raise ImportError("Installation of PyVerilator is required.")
@@ -193,12 +201,14 @@ def pyverilate_stitched_ip(model, read_internal_signals=True):
                 wf.write(rf.read())
 
     verilator_args = []
-    # disable common verilator warnings that should be harmless
-    verilator_args += ["-Wno-STMTDLY"]
-    verilator_args += ["-Wno-PINMISSING"]
-    verilator_args += ["-Wno-IMPLICIT"]
-    verilator_args += ["-Wno-WIDTH"]
-    verilator_args += ["-Wno-COMBDLY"]
+    # disable common verilator warnings that should be harmless but commonly occur
+    # in large quantities for Vivado HLS-generated verilog code
+    if disable_common_warnings:
+        verilator_args += ["-Wno-STMTDLY"]
+        verilator_args += ["-Wno-PINMISSING"]
+        verilator_args += ["-Wno-IMPLICIT"]
+        verilator_args += ["-Wno-WIDTH"]
+        verilator_args += ["-Wno-COMBDLY"]
     # force inlining of all submodules to ensure we can read internal signals properly
     if read_internal_signals:
         verilator_args += ["--inline-mult", "0"]


### PR DESCRIPTION
1. In some cases Verilator will not inline all FIFOs, hindering the current method for reading internal signals, which is required for the simulation-based automatic FIFO sizing in `InsertAndSetFIFODepths()`. Solved by forcing inlining with `--inline-mult 0` for now.
2. Disabled some of the most common warnings by default.

**Depends on a pyverilator PR: https://github.com/maltanar/pyverilator/pull/3**

To do: adjust finn commit pointers to finn-base & pyverilator accordingly.