### PR TITLE
Various fixes from multi-headed net testing

### DIFF
--- a/src/finn/core/modelwrapper.py
+++ b/src/finn/core/modelwrapper.py
@@ -217,7 +217,11 @@ class ModelWrapper:
         vi_names += [(x.name, x) for x in graph.output]
         vi_names += [(x.name, x) for x in graph.value_info]
         try:
-            vi_ind = [x[0] for x in vi_names].index(tensor_name)
+            vi_t_names = [x[0] for x in vi_names]
+            assert vi_t_names.count(tensor_name) <= 1, (
+                "Multiple ValueInfoProto found for " + tensor_name
+            )
+            vi_ind = vi_t_names.index(tensor_name)
             vi = vi_names[vi_ind][1]
             return vi
         except ValueError:
@@ -230,7 +234,11 @@ class ModelWrapper:
         vi_names += [(x.name, x) for x in graph.output]
         vi_names += [(x.name, x) for x in graph.value_info]
         try:
-            vi_ind = [x[0] for x in vi_names].index(tensor_name)
+            vi_t_names = [x[0] for x in vi_names]
+            assert vi_t_names.count(tensor_name) <= 1, (
+                "Multiple ValueInfoProto found for " + tensor_name
+            )
+            vi_ind = vi_t_names.index(tensor_name)
             vi = vi_names[vi_ind][1]
             dims = [x.dim_value for x in vi.type.tensor_type.shape.dim]
             return dims
@@ -240,6 +248,8 @@ class ModelWrapper:
     def set_tensor_shape(self, tensor_name, tensor_shape, dtype=TensorProto.FLOAT):
         """Assigns shape in ValueInfoProto for tensor with given name."""
         new_vi = oh.make_tensor_value_info(tensor_name, dtype, tensor_shape)
+        # call get_tensor_shape to catch multiple ValueInfoProto cases
+        self.get_tensor_shape(tensor_name)
         # find what container tis tensor's ValueInfo lives in
         # if not found anywhere, we assume it's a new value_info
         target_container = self.graph.value_info

--- a/src/finn/core/onnx_exec.py
+++ b/src/finn/core/onnx_exec.py
@@ -108,7 +108,9 @@ def execute_node(node, context, graph, return_full_exec_context=False):
             # graph.value_info as well as graph.output or graph.input
             # nodes with multiple outputs that are a mix of value_info and
             # input/outputs may get them reordered below
+            # note: a node's input may (also) be a top-level input or output
             node_inputs = list(filter(lambda x: x.name in node.input, graph.input))
+            node_inputs += list(filter(lambda x: x.name in node.input, graph.output))
             node_inputs += list(
                 filter(lambda x: x.name in node.input, graph.value_info)
             )

--- a/src/finn/custom_op/general/quantavgpool2d.py
+++ b/src/finn/custom_op/general/quantavgpool2d.py
@@ -94,7 +94,7 @@ class QuantAvgPool2d(CustomOp):
     def infer_node_datatype(self, model):
         node = self.onnx_node
         bw = self.get_nodeattr("obits")
-        if bw in [2, 4, 8, 16, 32]:
+        if bw in range(2, 33):
             if self.get_nodeattr("signed") == 0:
                 dtype = DataType["UINT%d" % bw]
             else:

--- a/src/finn/transformation/create_generic_partitions.py
+++ b/src/finn/transformation/create_generic_partitions.py
@@ -143,21 +143,11 @@ class PartitionFromLambda(Transformation):
 
             # remove redundant input and output value_info entries
             for i in p_in_vi:
-                # the tensor can be both an input and value_info, so we also have to
-                # ensure that the tensor is not a relevant value_info before removing
-                if (
-                    i in p_model.graph.value_info
-                    and p_model.find_producer(i.name) is None
-                ):
+                if i in p_model.graph.value_info:
                     p_model.graph.value_info.remove(i)
 
             for o in p_out_vi:
-                # the tensor can both an output and value_info, so we also have to
-                # ensure that the tensor is not a relevant value_info before removing
-                if (
-                    o in p_model.graph.value_info
-                    and p_model.find_consumers(o.name) is None
-                ):
+                if o in p_model.graph.value_info:
                     p_model.graph.value_info.remove(o)
 
             # save partition model

--- a/src/finn/transformation/general.py
+++ b/src/finn/transformation/general.py
@@ -134,9 +134,13 @@ class GiveReadableTensorNames(Transformation):
                 if model.get_initializer(i) is not None:
                     model.rename_tensor(i, "%s_param%d" % (n.name, init_in_num))
                     init_in_num += 1
-        # give special names to the main model input and output
-        model.rename_tensor(model.graph.input[0].name, "global_in")
-        model.rename_tensor(model.graph.output[0].name, "global_out")
+        # give special names to the model inputs and outputs
+        for i, inp in enumerate(model.graph.input):
+            iname = "global_in" if i == 0 else "global_in_%d" % i
+            model.rename_tensor(inp.name, iname)
+        for i, outp in enumerate(model.graph.output):
+            oname = "global_out" if i == 0 else "global_out_%d" % i
+            model.rename_tensor(outp.name, oname)
         # return model_was_changed = False as single iteration is always enough
         return (model, False)
 

--- a/src/finn/transformation/infer_datatypes.py
+++ b/src/finn/transformation/infer_datatypes.py
@@ -52,7 +52,8 @@ def _infer_node_datatype(model, node):
         "ScatterElements",
         "ScatterND",
         "Squeeze",
-        "Unsqueeze" "Tile",
+        "Unsqueeze",
+        "Tile",
     ]
     idtypes = list(map(lambda x: model.get_tensor_datatype(x), node.input))
     odtypes = list(map(lambda x: model.get_tensor_datatype(x), node.output))

--- a/src/finn/transformation/infer_datatypes.py
+++ b/src/finn/transformation/infer_datatypes.py
@@ -29,7 +29,7 @@
 import finn.custom_op.registry as registry
 from finn.core.datatype import DataType
 from finn.transformation.base import Transformation
-from finn.util.basic import is_finn_op
+from finn.util.basic import get_by_name, is_finn_op
 
 
 def _infer_node_datatype(model, node):
@@ -41,7 +41,18 @@ def _infer_node_datatype(model, node):
         "Flatten",
         "Slice",
         "Gather",
+        "GatherElements",
+        "GatherND",
         "Identity",
+        "Expand",
+        "Flatten",
+        "MaxPool",
+        "GlobalMaxPool",
+        "Scatter",
+        "ScatterElements",
+        "ScatterND",
+        "Squeeze",
+        "Unsqueeze" "Tile",
     ]
     idtypes = list(map(lambda x: model.get_tensor_datatype(x), node.input))
     odtypes = list(map(lambda x: model.get_tensor_datatype(x), node.output))
@@ -72,6 +83,16 @@ def _infer_node_datatype(model, node):
                 else:
                     odtype = DataType.UINT32
                 model.set_tensor_datatype(node.output[0], odtype)
+        elif node.op_type in ["Resize", "Upsample"]:
+            mode = get_by_name(node.attribute, "mode").s
+            if mode is None:
+                mode = "nearest"
+            else:
+                mode = mode.decode("UTF-8")
+            if mode == "nearest":
+                # set output dtype = input dtype
+                idtype = model.get_tensor_datatype(node.input[0])
+                model.set_tensor_datatype(node.output[0], idtype)
         elif node.op_type in dt_identity_optypes:
             # set output dtype = input dtype
             idtype = model.get_tensor_datatype(node.input[0])

--- a/src/finn/transformation/make_input_chanlast.py
+++ b/src/finn/transformation/make_input_chanlast.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2021 Xilinx, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of Xilinx nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from onnx import helper as oh
+
+import finn.core.data_layout as data_layout
+from finn.transformation.base import Transformation
+
+
+class MakeInputChannelsLast(Transformation):
+    """For networks with an input using the NCx data layout, add a transpose node
+    at the beginning and mark the input as using NxC (channels-last)."""
+
+    def __init__(self):
+        super().__init__()
+
+    def apply(self, model):
+        graph_in_name = model.graph.input[0].name
+        graph_new_in_name = graph_in_name + "_transposed"
+        orig_ishape = model.get_tensor_shape(graph_in_name)
+        ndim = len(orig_ishape)
+        if ndim == 2:
+            # assume NC layout, no action needed
+            return (model, False)
+        elif ndim > 2:
+            orig_layout = model.get_tensor_layout(graph_in_name)
+            if orig_layout == data_layout.get_channels_last_layout_for_ndims(ndim):
+                # already marked as channels-last, no action needed
+                return (model, False)
+            else:
+                # determine channels-last shape and required permutation to
+                # go from channels-last to previous format
+                new_perm = list(range(ndim))
+                new_perm.remove(ndim - 1)
+                new_perm.insert(1, ndim - 1)
+                new_ishape = list(orig_ishape)
+                new_ishape.remove(orig_ishape[1])
+                new_ishape.append(orig_ishape[1])
+                # create and insert transpose node
+                t_trans_node = oh.make_node(
+                    "Transpose", [graph_in_name], [graph_new_in_name], perm=new_perm
+                )
+                model.graph.node.insert(0, t_trans_node)
+                # rewire all consumers of original input to transpose's output
+                consumers = model.find_consumers(graph_in_name)
+                for cons in consumers:
+                    if cons == t_trans_node:
+                        continue
+                    for i, ci in enumerate(cons.input):
+                        if ci == graph_in_name:
+                            cons.input[i] = graph_new_in_name
+                # set tensor shapes and layouts
+                model.set_tensor_shape(graph_in_name, new_ishape)
+                model.set_tensor_shape(graph_new_in_name, orig_ishape)
+                model.set_tensor_layout(
+                    graph_in_name, data_layout.get_channels_last_layout_for_ndims(ndim)
+                )
+                model.set_tensor_layout(
+                    graph_new_in_name,
+                    data_layout.get_channels_first_layout_for_ndims(ndim),
+                )
+                # single iteration is enough so return model_was_changed=False
+                return (model, False)

--- a/tests/transformation/test_batchnorm_to_affine.py
+++ b/tests/transformation/test_batchnorm_to_affine.py
@@ -64,7 +64,7 @@ def test_batchnorm_to_affine_shufflenet():
     op_types = list(map(lambda x: x.op_type, new_model.graph.node))
     assert "BatchNormalization" not in op_types
     produced = oxe.execute_onnx(new_model, input_dict)[oname]
-    assert np.isclose(expected, produced).all()
+    assert np.isclose(expected, produced, atol=1e-05).all()
     os.remove(export_onnx_path)
 
 

--- a/tests/transformation/test_infer_datatypes.py
+++ b/tests/transformation/test_infer_datatypes.py
@@ -46,13 +46,10 @@ def test_infer_datatypes():
     # this model has no DataType info, so add some DataType annotation
     # to make things a bit more exciting
     model.set_tensor_datatype("global_in", DataType.UINT8)
-    # manual non-float annotations on regular ONNX nodes won't disappear
-    # (InferDataTypes assumes they've been put there with good reason)
-    model.set_tensor_datatype("MaxPool_1_out0", DataType.INT4)
-    # MatMul with int weights + inputs will have int output datatype
-    model.set_tensor_datatype("MatMul_0_param0", DataType.UINT8)
+    # Conv with int weights + inputs will have int output datatype
+    model.set_tensor_datatype("Conv_0_param0", DataType.INT4)
     model = model.transform(InferDataTypes())
     assert model.get_tensor_datatype("global_in") == DataType.UINT8
-    assert model.get_tensor_datatype("Reshape_0_out0") == DataType.INT4
-    assert model.get_tensor_datatype("MatMul_0_out0") == DataType.INT32
+    assert model.get_tensor_datatype("Conv_0_out0") == DataType.INT32
+    assert model.get_tensor_datatype("Relu_0_out0") == DataType.FLOAT32
     assert model.get_tensor_datatype("global_out") == DataType.FLOAT32


### PR DESCRIPTION
Various fixes and improvements from feedback on multi-headed net testing:
* Several important fixes to core components re. duplicate VIPs and execution of nodes whose input is also a graph output, as well as to generic partitioning (eliminate duplicate VIPs)
* More data layout variants and a new `MakeInputChanLast` transformation to convert convnets to channels-last input
* More high-level/identity-behavior layers supported in datatype inference
* Other minor fixes