### PR TITLE
Support and tests for unsetting FINN data types.

### DIFF
--- a/src/finn/core/modelwrapper.py
+++ b/src/finn/core/modelwrapper.py
@@ -197,13 +197,16 @@ class ModelWrapper:
                 ret.quant_parameter_tensor_names, "finn_datatype", "key"
             )
             if ret_dt is not None:
-                ret_dt.value = datatype.name
-            else:
+                if datatype is None:
+                    ret_dt.Clear()
+                else:
+                    ret_dt.value = datatype.name
+            elif datatype is not None:
                 dt = onnx.StringStringEntryProto()
                 dt.key = "finn_datatype"
                 dt.value = datatype.name
                 ret.quant_parameter_tensor_names.append(dt)
-        else:
+        elif datatype is not None:
             qa = onnx.TensorAnnotation()
             dt = onnx.StringStringEntryProto()
             dt.key = "finn_datatype"

--- a/tests/core/test_modelwrapper.py
+++ b/tests/core/test_modelwrapper.py
@@ -31,6 +31,7 @@ import onnx
 from pkgutil import get_data
 
 import finn.core.data_layout as DataLayout
+from finn.core.datatype import DataType
 from finn.core.modelwrapper import ModelWrapper
 
 
@@ -166,3 +167,37 @@ def test_modelwrapper_detect_forks_n_joins():
     assert not model.is_join_node(Round_node)
     assert not model.is_join_node(Ceil_node)
     assert model.is_join_node(Add_node)
+
+
+def test_modelwrapper_setting_unsetting_datatypes():
+    # Set and unset some datatypes and check for expected return values
+    raw_m = get_data("finn.data", "onnx/mnist-conv/model.onnx")
+    model = ModelWrapper(raw_m)
+
+    test_node = model.graph.node[0]
+    test_tensor = test_node.output[0]
+
+    ret = model.get_tensor_datatype(test_tensor)
+    assert (
+        ret == DataType["FLOAT32"]
+    ), "Tensor datatype should be float32 for no initalization."
+
+    model.set_tensor_datatype(test_tensor, None)
+    ret = model.get_tensor_datatype(test_tensor)
+    assert ret == DataType["FLOAT32"], "An unset datatype should return float32."
+
+    model.set_tensor_datatype(test_tensor, DataType["INT3"])
+    ret = model.get_tensor_datatype(test_tensor)
+    assert ret == DataType["INT3"], "Tensor datatype should follow setting."
+
+    model.set_tensor_datatype(test_tensor, None)
+    ret = model.get_tensor_datatype(test_tensor)
+    assert ret == DataType["FLOAT32"], "An unset datatype should return float32."
+
+    model.set_tensor_datatype(test_tensor, DataType["BIPOLAR"])
+    ret = model.get_tensor_datatype(test_tensor)
+    assert ret == DataType["BIPOLAR"], "Tensor datatype should follow setting."
+
+    model.set_tensor_datatype(test_tensor, None)
+    ret = model.get_tensor_datatype(test_tensor)
+    assert ret == DataType["FLOAT32"], "An unset datatype should return float32."

--- a/tests/core/test_modelwrapper.py
+++ b/tests/core/test_modelwrapper.py
@@ -190,6 +190,10 @@ def test_modelwrapper_setting_unsetting_datatypes():
     ret = model.get_tensor_datatype(test_tensor)
     assert ret == DataType["INT3"], "Tensor datatype should follow setting."
 
+    model.set_tensor_datatype(test_tensor, DataType["UINT4"])
+    ret = model.get_tensor_datatype(test_tensor)
+    assert ret == DataType["UINT4"], "Tensor datatype should follow setting."
+
     model.set_tensor_datatype(test_tensor, None)
     ret = model.get_tensor_datatype(test_tensor)
     assert ret == DataType["FLOAT32"], "An unset datatype should return float32."
@@ -197,7 +201,3 @@ def test_modelwrapper_setting_unsetting_datatypes():
     model.set_tensor_datatype(test_tensor, DataType["BIPOLAR"])
     ret = model.get_tensor_datatype(test_tensor)
     assert ret == DataType["BIPOLAR"], "Tensor datatype should follow setting."
-
-    model.set_tensor_datatype(test_tensor, None)
-    ret = model.get_tensor_datatype(test_tensor)
-    assert ret == DataType["FLOAT32"], "An unset datatype should return float32."


### PR DESCRIPTION
Hi,
during the QONNX to FINN ONNX conversion I have to unset some of the tensor data types. This happens in particular when the Quant nodes in the activation path get converted to MultiThreshold nodes.

This PR adds functionality to unset a FINN datatype with the following function call:
`model.set_tensor_datatype(tensor_name, None)`

Additionally a new test is included which verifies this behavior.