### PR TITLE
finn-base v0.0.3

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,16 +1,11 @@
 # This workflow will upload a Python Package using Twine when a release is created
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 name: Upload Python Package
 
 on:
   release:
-    types: [published]
+    types: [created]
 
 jobs:
   deploy:
@@ -26,11 +21,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install build
-    - name: Build package
-      run: python -m build
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      run: |
+        python setup.py sdist
+        twine upload dist/*

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,3 +11,4 @@ Contributors
 * Mirza Mrahorovic (@mmrahorovic)
 * Felix Paul Jentzsch (@felixpj)
 * Jon Ander Lezeta (@jalezeta)
+* Radoslav Pitoňák (@rpitonak)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## <img src=https://raw.githubusercontent.com/Xilinx/finn/master/docs/img/finn-logo.png width=128/> Core Components for Quantized Neural Network Inference
+## <img src=https://raw.githubusercontent.com/Xilinx/finn/github-pages/docs/img/finn-logo.png width=128/> Core Components for Quantized Neural Network Inference
 
 [![Gitter](https://badges.gitter.im/xilinx-finn/community.svg)](https://gitter.im/xilinx-finn/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![ReadTheDocs](https://readthedocs.org/projects/finn-base/badge/?version=latest&style=plastic)](http://finn-base.readthedocs.io/)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -73,7 +73,7 @@ RUN python -mpip install --upgrade pip && \
     rm requirements.txt
 
 # Install custom fork of pyverilator
-RUN pip install git+https://github.com/maltanar/pyverilator.git#egg=pyverilator
+RUN pip install git+https://github.com/maltanar/pyverilator.git@0c3eb9343500fc1352a02c020a736c8c2db47e8e
 
 # Install pytest-xdist (not in requirements, only for faster testing in Docker)
 RUN pip install pytest-xdist==2.0.0

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,4 +1,5 @@
 bitstring>=3.1.7
+clize==4.1.1
 numpy
 onnx==1.7.0
 onnxruntime==1.4.0

--- a/docs/QONNX/bipolar_quant_op.md
+++ b/docs/QONNX/bipolar_quant_op.md
@@ -1,0 +1,92 @@
+### <a name="BipolarQuant"></a><a name="abs">**BipolarQuant**</a>
+
+Calculates the binary quantized values of one input data (Tensor<T>) and produces one output data (Tensor<T>).
+Additionally, takes one float as input, which define the scaling.
+
+#### Version
+
+This operator is not part of the ONNX standard and is not currently versioned.
+
+#### Attributes
+
+<dl>
+</dl>
+
+#### Inputs
+
+<dl>
+<dt><tt>X</tt> (differentiable) : tensor(float32)</dt>
+<dd>input tensor to quantize</dd>
+<dt><tt>scale</tt> : float32</dt>
+<dd>The scale factor</dd>
+</dl>
+
+
+#### Outputs
+
+<dl>
+<dt><tt>Y</tt> (differentiable) : tensor(float32)</dt>
+<dd>Output tensor</dd>
+</dl>
+
+
+#### Examples
+<details>
+<summary>BipolarQuant</summary>
+
+```python
+from onnx import helper
+import numpy as np
+
+# Define node settings and input
+x = np.random.randn(100).astype(np.float32)*10.
+scale = np.array(1.)
+
+# Create node
+node = helper.make_node(
+    'BipolarQuant',
+    domain='finn.custom_op.general',
+    inputs=['x', 'scale'],
+    outputs=['y'],
+)
+
+# Execute the same settings with the reference implementation (quant)
+# See the sample implementation for more details on quant.
+output_ref = binary_quant(x, scale)
+
+# Execute node and compare
+expect(node, inputs=[x, scale], outputs=[output_ref], name='test_binary_quant')
+
+```
+
+</details>
+
+
+#### Sample Implementation
+
+<details>
+<summary>BipolarQuant</summary>
+
+```python
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import numpy as np
+
+def binary_quant(inp_tensor, scale):
+    # Quantizing
+    y_int = inp_tensor
+    y_ones = np.ones(y_int.shape, dtype=y_int.dtype)
+    y_int = np.where(y_int >= 0.0, y_ones, -y_ones)
+    # Scaling
+    out_tensor = y_int * scale
+
+    return out_tensor
+
+```
+
+</details>

--- a/docs/QONNX/quant_op.md
+++ b/docs/QONNX/quant_op.md
@@ -1,0 +1,193 @@
+### <a name="Quant"></a><a name="abs">**Quant**</a>
+
+Calculates the quantized values of one input data (Tensor<T>) and produces one output data (Tensor<T>).
+Additionally, takes three floats as input, which define the scale, zero-point and bit-width of the quantization.
+The attributes narrow and signed define how the bits of the quantization are interpreted, while the attribute
+rounding_mode defines how quantized values are rounded.
+
+Note: This operator does not work for binary or bipolar quantization, for this purpose the simpler BipolarQuant node exists.
+
+#### Version
+
+This operator is not part of the ONNX standard and is not currently versioned.
+
+#### Attributes
+
+<dl>
+<dt><tt>signed</tt> : int (default is 1)</dt>
+<dd>Defines if the quantization includes a signed bit. E.g. at 8b unsigned=[0, 255] vs signed=[-128, 127].</dd>
+<dt><tt>narrow</tt> : int (default is 0)</dt>
+<dd>Defines if the value range should be interpreted as narrow, when signed=1. E.g. at 8b regular=[-128, 127] vs narrow=[-127, 127].</dd>
+<dt><tt>rounding_mode</tt> : string (default is "ROUND")</dt>
+<dd>Defines how rounding should be applied during quantization. Currently available modes are: "ROUND", "CEIL" and "FLOOR". Here "ROUND" implies a round-to-even operation.</dd>
+</dl>
+
+#### Inputs
+
+<dl>
+<dt><tt>X</tt> (differentiable) : tensor(float32)</dt>
+<dd>input tensor to quantize</dd>
+<dt><tt>scale</tt> : float32</dt>
+<dd>The scale factor</dd>
+<dt><tt>zeropt</tt> : float32</dt>
+<dd>The zero-point</dd>
+<dt><tt>bitwidth</tt> : int32</dt>
+<dd>The number of bits used by the quantization</dd>
+</dl>
+
+
+#### Outputs
+
+<dl>
+<dt><tt>Y</tt> (differentiable) : tensor(float32)</dt>
+<dd>Output tensor</dd>
+</dl>
+
+
+#### Examples
+<details>
+<summary>Quant</summary>
+
+```python
+from onnx import helper
+import numpy as np
+
+# Define node settings and input
+x = np.random.randn(100).astype(np.float32)*10.
+scale = np.array(1.)
+zeropt = np.array(0.)
+bitwidth = np.array(4)
+signed = 1
+narrow = 0
+rounding_mode = "ROUND"
+
+# Create node
+node = helper.make_node(
+    'Quant',
+    domain='finn.custom_op.general',
+    inputs=['x', 'scale', 'zeropt', 'bitwidth'],
+    outputs=['y'],
+    narrow=narrow,
+    signed=signed,
+    rounding_mode=rounding_mode,
+)
+
+# Execute the same settings with the reference implementation (quant)
+# See the sample implementation for more details on quant.
+output_ref = quant(x, scale, zeropt, bitwidth, signed, narrow, rounding_mode)
+
+# Execute node and compare
+expect(node, inputs=[x, scale, zeropt, bitwidth], outputs=[output_ref], name='test_quant')
+
+```
+
+</details>
+
+
+#### Sample Implementation
+
+<details>
+<summary>Quant</summary>
+
+```python
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import numpy as np
+
+def quant(inp_tensor, scale, zeropt, bitwidth, signed, narrow, rounding_mode):
+    # Port of IntQuant class from Brevitas: https://bit.ly/2S6qvZJ
+    # Scaling
+    y_int = inp_tensor / scale
+    y_int = y_int + zeropt
+    # Clamping
+    min_int_val = min_int(signed, narrow, bitwidth)
+    max_int_val = max_int(signed, narrow, bitwidth)
+    y_int = np.where(y_int > max_int_val, max_int_val.astype(y_int.dtype), y_int)
+    y_int = np.where(y_int < min_int_val, min_int_val.astype(y_int.dtype), y_int)
+    # Rounding
+    rounding_fx = resolve_rounding_mode(rounding_mode)
+    y_int = rounding_fx(y_int)
+
+    # Re-scaling
+    out_tensor = y_int - zeropt
+    out_tensor = out_tensor * scale
+
+    return out_tensor
+
+def min_int(signed: bool, narrow_range: bool, bit_width: int) -> int:
+    """Compute the minimum integer representable by a given number of bits.
+    Args:
+        signed (bool): Indicates whether the represented integer is signed or not.
+        narrow_range (bool): Indicates whether to narrow the minimum value
+        represented by 1.
+        bit_width (int): Number of bits available for the representation.
+    Returns:
+        int: Maximum unsigned integer that can be represented according to
+        the input arguments.
+    Examples:
+        >>> min_int(signed=True, narrow_range=True, bit_width=8)
+        int(-127)
+        >>> min_int(signed=False, narrow_range=True, bit_width=8)
+        int(0)
+        >>> min_int(signed=True, narrow_range=False, bit_width=8)
+        int(-128)
+        >>> min_int(signed=False, narrow_range=False, bit_width=8)
+        int(0)
+    """
+    if signed and narrow_range:
+        value = -(2 ** (bit_width - 1)) + 1
+    elif signed and not narrow_range:
+        value = -(2 ** (bit_width - 1))
+    else:
+        value = 0 * bit_width
+    return value
+
+
+def max_int(signed: bool, narrow_range: bool, bit_width: int) -> int:
+    """Compute the maximum integer representable by a given number of bits.
+    Args:
+        signed (bool): Indicates whether the represented integer is signed or not.
+        narrow_range (bool): Indicates whether to narrow the maximum unsigned value
+        represented by 1.
+        bit_width (int): Number of bits available for the representation.
+    Returns:
+        Tensor: Maximum integer that can be represented according to
+        the input arguments.
+    Examples:
+        >>> max_int(signed=True, narrow_range=True, bit_width=8)
+        int(127)
+        >>> max_int(signed=False, narrow_range=True, bit_width=8)
+        int(254)
+        >>> max_int(signed=True, narrow_range=False, bit_width=8)
+        int(127)
+        >>> max_int(signed=False, narrow_range=False, bit_width=8)
+        int(255)
+    """
+    if not signed and not narrow_range:
+        value = (2 ** bit_width) - 1
+    elif not signed and narrow_range:
+        value = (2 ** bit_width) - 2
+    else:
+        value = (2 ** (bit_width - 1)) - 1
+    return value
+
+def resolve_rounding_mode(mode_string):
+    """Resolve the rounding mode string of Quant and Trunc ops
+    to the corresponding numpy functions."""
+    if mode_string == "ROUND":
+        return np.round
+    elif mode_string == "CEIL":
+        return np.ceil
+    elif mode_string == "FLOOR":
+        return np.floor
+    else:
+        raise ValueError(f"Could not resolve rounding mode called: {mode_string}")
+
+```
+
+</details>

--- a/docs/QONNX/trunc_op.md
+++ b/docs/QONNX/trunc_op.md
@@ -1,0 +1,131 @@
+### <a name="Trunc"></a><a name="abs">**Trunc**</a>
+
+Truncates the values of one input data (Tensor<T>) at a specified bitwidth and produces one output data (Tensor<T>).
+Additionally, takes four float tensors as input, which define the scale, zero-point, input bit-width and output bit-width of the quantization.
+The attribute rounding_mode defines how truncated values are rounded.
+
+#### Version
+
+This operator is not part of the ONNX standard and is not currently versioned.
+
+#### Attributes
+
+<dl>
+<dt><tt>rounding_mode</tt> : string (default is "FLOOR")</dt>
+<dd>Defines how rounding should be applied during truncation. Currently available modes are: "ROUND", "CEIL" and "FLOOR". Here "ROUND" implies a round-to-even operation.</dd>
+</dl>
+
+#### Inputs
+
+<dl>
+<dt><tt>X</tt> (differentiable) : tensor(float32)</dt>
+<dd>input tensor to truncate</dd>
+<dt><tt>scale</tt> : float32</dt>
+<dd>The scale factor</dd>
+<dt><tt>zeropt</tt> : float32</dt>
+<dd>The zero-point</dd>
+<dt><tt>in_bitwidth</tt> : int32</dt>
+<dd>The number of bits used at the input of the truncation</dd>
+<dt><tt>out_bitwidth</tt> : int32</dt>
+<dd>The number of bits used at the output of the truncation</dd>
+</dl>
+
+
+#### Outputs
+
+<dl>
+<dt><tt>Y</tt> (differentiable) : tensor(float32)</dt>
+<dd>Output tensor</dd>
+</dl>
+
+
+#### Examples
+<details>
+<summary>Trunc</summary>
+
+```python
+from onnx import helper
+import numpy as np
+
+# Define node settings and input
+x = np.random.randn(100).astype(np.float32)*10.
+scale = np.array(1.)
+zeropt = np.array(0.)
+in_bitwidth = np.array(10)
+out_bitwidth = np.array(4)
+rounding_mode = "ROUND"
+
+# Create node
+node = helper.make_node(
+    'Trunc',
+    domain='finn.custom_op.general',
+    inputs=['x', 'scale', 'zeropt', 'in_bitwidth', 'out_bitwidth'],
+    outputs=['y'],
+    rounding_mode=rounding_mode,
+)
+
+# Execute the same settings with the reference implementation (trunc)
+# See the sample implementation for more details on trunc.
+output_ref = trunc(inp_tensor, scale, zeropt, in_bitwidth, out_bitwidth, rounding_mode)
+
+# Execute node and compare
+expect(node, inputs=[x, scale, zeropt, bitwidth], outputs=[output_ref], name='test_trunc')
+
+```
+
+</details>
+
+
+#### Sample Implementation
+
+<details>
+<summary>Trunc</summary>
+
+```python
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import numpy as np
+
+def trunc(inp_tensor, scale, zeropt, input_bit_width, output_bit_width, rounding_mode):
+    # Port of TruncIntQuant class from Brevitas: https://bit.ly/3wzIpTR
+
+    # Scaling
+    y = inp_tensor / scale
+    y = y + zeropt
+    # Rounding
+    y = np.round(y)
+    # Truncate
+    trunc_bit_width = input_bit_width - output_bit_width
+    trunc_scale = 2.0 ** trunc_bit_width
+    y = y / trunc_scale
+
+    # To int
+    rounding_fx = resolve_rounding_mode(rounding_mode)
+    y = rounding_fx(y)
+
+    # Rescale
+    y = y - zeropt
+    y = y * scale
+
+    return y
+
+def resolve_rounding_mode(mode_string):
+    """Resolve the rounding mode string of Quant and Trunc ops
+    to the corresponding numpy functions."""
+    if mode_string == "ROUND":
+        return np.round
+    elif mode_string == "CEIL":
+        return np.ceil
+    elif mode_string == "FLOOR":
+        return np.floor
+    else:
+        raise ValueError(f"Could not resolve rounding mode called: {mode_string}")
+
+```
+
+</details>

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,7 @@ docs =
     sphinx>=3.2.1
     sphinx_rtd_theme>=0.5.0
 onnx =
+    clize==4.1.1
     onnx==1.7.0
     onnxruntime==1.4.0
     toposort>=1.5.0
@@ -63,6 +64,8 @@ testing =
     pytest-cov
 
 [options.entry_points]
+console_scripts =
+    inference_cost = finn.util.inference_cost:main
 # Add here console scripts like:
 # console_scripts =
 #     script_name = finn.finn_base.module:function

--- a/src/finn/analysis/inference_cost.py
+++ b/src/finn/analysis/inference_cost.py
@@ -1,0 +1,249 @@
+# Copyright (c) 2021 Xilinx, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distributionode.
+#
+# * Neither the name of Xilinx nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permissionode.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import numpy as np
+
+from finn.util.basic import get_by_name
+
+
+def get_node_tensor_dtypes(model, node):
+    # input tensor (input 0)
+    i_name = node.input[0]
+    i_dtype = model.get_tensor_datatype(i_name)
+    # weight tensor (input 1)
+    w_name = node.input[1]
+    w_dtype = model.get_tensor_datatype(w_name)
+    # output tensor (input 0)
+    o_name = node.output[0]
+    o_dtype = model.get_tensor_datatype(o_name)
+    return (i_dtype, w_dtype, o_dtype)
+
+
+def get_node_tensor_shapes(model, node):
+    # input tensor (input 0)
+    i_name = node.input[0]
+    i_shape = model.get_tensor_shape(i_name)
+    assert i_shape is not None, "Input has undefined shape: " + str(node)
+    # weight tensor (input 1)
+    w_name = node.input[1]
+    w_shape = model.get_tensor_shape(w_name)
+    assert w_shape is not None, "Weight has undefined shape: " + str(node)
+    # output tensor (output 0)
+    o_name = node.output[0]
+    o_shape = model.get_tensor_shape(o_name)
+    assert o_shape is not None, "Output has undefined shape: " + str(node)
+    return (i_shape, w_shape, o_shape)
+
+
+def get_node_weight_density(model, w_name):
+    w_tensor = model.get_initializer(w_name)
+    if w_tensor is None:
+        return 1.0
+    w_total = np.prod(w_tensor.shape)
+    w_density = np.count_nonzero(w_tensor) / w_total
+    return w_density
+
+
+def aggregate_dict_keys(res_dict):
+    total_dict = {}
+    for layer in res_dict:
+        layer_res_dict = res_dict[layer]
+        for r_type in layer_res_dict.keys():
+            if "efficiency" in r_type:
+                continue
+            r_amount = layer_res_dict[r_type]
+            r_amount = float(r_amount)
+            if r_type in total_dict.keys():
+                total_dict[r_type] += r_amount
+            else:
+                total_dict[r_type] = r_amount
+    return total_dict
+
+
+def inference_cost_conv(model, node, discount_sparsity):
+    # extract info about the conv kernel attributes
+    k = get_by_name(node.attribute, "kernel_shape").ints
+    k_prod = np.prod(k)
+    group = get_by_name(node.attribute, "group")
+    if group is None:
+        group = 1
+    else:
+        group = group.i
+    # extract info from tensor shapes and datatypes
+    (i_dtype, w_dtype, o_dtype) = get_node_tensor_dtypes(model, node)
+    (i_shape, w_shape, o_shape) = get_node_tensor_shapes(model, node)
+    bsize = i_shape[0]
+    ifm_ch = i_shape[1]
+    ofm_ch = o_shape[1]
+    assert ofm_ch == w_shape[0], "Mismatch in output channels"
+    assert ofm_ch % group == 0, "Invalid group setting: " + str(node)
+    ofm_pix_total = np.prod(o_shape[2:])
+    n_macs = bsize * (ofm_ch // group) * ifm_ch * k_prod * ofm_pix_total
+    w_mem = np.prod(w_shape)
+    o_mem = np.prod(o_shape)
+    if discount_sparsity:
+        wname = node.input[1]
+        density = get_node_weight_density(model, wname)
+        n_macs *= density
+        w_mem *= density
+    idt_name = i_dtype.name
+    wdt_name = w_dtype.name
+    odt_name = o_dtype.name
+    mac_op_type_str = "op_mac_%s_%s" % (idt_name, wdt_name)
+    w_mem_type_str = "mem_w_%s" % (wdt_name)
+    o_mem_type_str = "mem_o_%s" % (odt_name)
+    ret = {mac_op_type_str: n_macs, w_mem_type_str: w_mem, o_mem_type_str: o_mem}
+    return ret
+
+
+def inference_cost_matmul(model, node, discount_sparsity):
+    # extract info from tensor shapes and datatypes
+    (i_dtype, w_dtype, o_dtype) = get_node_tensor_dtypes(model, node)
+    (i_shape, w_shape, o_shape) = get_node_tensor_shapes(model, node)
+    if node.op_type == "Gemm":
+        assert len(i_shape) == 2 and len(w_shape) == 2
+        tA = get_by_name(node.attribute, "transA")
+        tB = get_by_name(node.attribute, "transB")
+        if tA is not None and tA.i == 1:
+            i_shape = i_shape[::-1]
+        if tB is not None and tB.i == 1:
+            w_shape = w_shape[::-1]
+    # exclude common dim (last axis) from one side to avoid duplication
+    n_macs = np.prod(i_shape[:-1]) * np.prod(w_shape)
+    # deal with both dyn,param and dyn,dyn cases for weight memory
+    inp0_is_const = model.get_initializer(node.input[0]) is not None
+    inp1_is_const = model.get_initializer(node.input[1]) is not None
+    if inp0_is_const and (not inp1_is_const):
+        # inp 0 is static
+        w_mem = np.prod(i_shape)
+        wname = node.input[0]
+    elif (not inp0_is_const) and inp1_is_const:
+        # inp 1 is static
+        w_mem = np.prod(w_shape)
+        wname = node.input[1]
+    elif (not inp0_is_const) and (not inp1_is_const):
+        # both inputs dynamic
+        w_mem = 0
+        wname = None
+    if discount_sparsity and wname is not None:
+        density = get_node_weight_density(model, wname)
+        n_macs *= density
+        w_mem *= density
+    o_mem = np.prod(o_shape)
+    idt_name = i_dtype.name
+    wdt_name = w_dtype.name
+    odt_name = o_dtype.name
+    mac_op_type_str = "op_mac_%s_%s" % (idt_name, wdt_name)
+    w_mem_type_str = "mem_w_%s" % (wdt_name)
+    o_mem_type_str = "mem_o_%s" % (odt_name)
+    ret = {mac_op_type_str: n_macs, w_mem_type_str: w_mem, o_mem_type_str: o_mem}
+    return ret
+
+
+def inference_cost_upsample(model, node, discount_sparsity):
+    # extract info about the upsampling kernel attributes
+    mode = get_by_name(node.attribute, "mode").s.decode("utf-8")
+    scales_tensor = node.input[1]
+    scales_initializer = model.get_initializer(scales_tensor)
+
+    # extract info from tensor shapes and datatypes
+    (i_dtype, scale_dtype, o_dtype) = get_node_tensor_dtypes(model, node)
+    (i_shape, scale_shape, o_shape) = get_node_tensor_shapes(model, node)
+    bsize = i_shape[0]
+    ifm_ch = i_shape[1]
+    ofm_pix_total = np.prod(o_shape[2:])
+
+    # MAC calculation
+    if mode == "nearest":
+        # No calculation involved, since data is just copied over multiple times
+        n_macs = 0
+    elif mode == "linear":
+        # Data gets linearly interpolated in each dimension
+        # Two MACs per dimension and output pixel assumed
+        n_dim_scaling = np.sum(scales_initializer > 1)
+        n_macs = 2 * n_dim_scaling * ofm_pix_total * ifm_ch * bsize
+    else:
+        raise ValueError(f"Upsampling mode {mode} not supported for estimation.")
+
+    # Mem calculation
+    o_mem = np.prod(o_shape)
+    idt_name = i_dtype.name
+    odt_name = o_dtype.name
+    mac_op_type_str = "op_mac_%s_%s" % (idt_name, idt_name)
+    o_mem_type_str = "mem_o_%s" % (odt_name)
+
+    ret = {mac_op_type_str: n_macs, o_mem_type_str: o_mem}
+    return ret
+
+
+def inference_cost(model, discount_sparsity=True):
+    "Ensure all nodes have unique names prior to calling this analysis pass."
+
+    node_costs = {}
+    zero_cost_ops = [
+        "MaxPool",
+        "AveragePool",
+        "Quant",
+        "Reshape",
+        "Concat",
+        "Transpose",
+        "Div",
+        "Mul",
+        "Add",
+        "Sub",
+        "BatchNormalization",
+        "Relu",
+        "Elu",
+        "Selu",
+        "Sigmoid",
+        "Identity",
+        "Flatten",
+    ]
+    unsupported_ops = set()
+    inference_cost_fxn_map = {
+        "Conv": inference_cost_conv,
+        "MatMul": inference_cost_matmul,
+        "Gemm": inference_cost_matmul,
+        "Upsample": inference_cost_upsample,
+    }
+    for node in model.graph.node:
+        if node.op_type in inference_cost_fxn_map.keys():
+            node_cost = inference_cost_fxn_map[node.op_type](
+                model, node, discount_sparsity
+            )
+            node_costs[node.name] = node_cost
+        elif node.op_type in zero_cost_ops:
+            continue
+        else:
+            unsupported_ops.add(node.op_type)
+
+    ret = aggregate_dict_keys(node_costs)
+    ret["unsupported"] = unsupported_ops
+    ret["discount_sparsity"] = discount_sparsity
+
+    return ret

--- a/src/finn/core/datatype.py
+++ b/src/finn/core/datatype.py
@@ -54,6 +54,12 @@ class BaseDataType(ABC):
     def name(self):
         return self.get_canonical_name()
 
+    def __repr__(self):
+        return self.get_canonical_name()
+
+    def __str__(self):
+        return self.get_canonical_name()
+
     @abstractmethod
     def bitwidth(self):
         "Returns the number of bits required for this DataType."

--- a/src/finn/core/datatype.py
+++ b/src/finn/core/datatype.py
@@ -28,218 +28,336 @@
 
 
 import numpy as np
-from enum import Enum, auto
+from abc import ABC, abstractmethod
+from enum import Enum, EnumMeta
 
 
-class DataType(Enum):
-    """Enum class that contains FINN data types to set the quantization annotation.
-    ONNX does not support data types smaller than 8-bit integers, whereas in FINN we are
-    interested in smaller integers down to ternary and bipolar.
+class BaseDataType(ABC):
+    "Base class for FINN data types."
 
-    Assignment of DataTypes to indices based on following ordering:
+    def signed(self):
+        "Returns whether this DataType can represent negative numbers."
+        return self.min() < 0
 
-    * unsigned to signed
+    def __eq__(self, other):
+        if isinstance(other, BaseDataType):
+            return self.get_canonical_name() == other.get_canonical_name()
+        elif isinstance(other, str):
+            return self.get_canonical_name() == other
+        else:
+            return NotImplemented
 
-    * fewer to more bits
+    def __hash__(self):
+        return hash(self.get_canonical_name())
 
-    Currently supported DataTypes:"""
+    @property
+    def name(self):
+        return self.get_canonical_name()
 
-    # important: the get_smallest_possible() member function is dependent on ordering.
-    BINARY = auto()
-    UINT2 = auto()
-    UINT3 = auto()
-    UINT4 = auto()
-    UINT5 = auto()
-    UINT6 = auto()
-    UINT7 = auto()
-    UINT8 = auto()
-    UINT9 = auto()
-    UINT10 = auto()
-    UINT11 = auto()
-    UINT12 = auto()
-    UINT13 = auto()
-    UINT14 = auto()
-    UINT15 = auto()
-    UINT16 = auto()
-    UINT17 = auto()
-    UINT18 = auto()
-    UINT19 = auto()
-    UINT20 = auto()
-    UINT21 = auto()
-    UINT22 = auto()
-    UINT23 = auto()
-    UINT24 = auto()
-    UINT25 = auto()
-    UINT26 = auto()
-    UINT27 = auto()
-    UINT28 = auto()
-    UINT29 = auto()
-    UINT30 = auto()
-    UINT31 = auto()
-    UINT32 = auto()
-    UINT64 = auto()
-    BIPOLAR = auto()
-    TERNARY = auto()
-    INT2 = auto()
-    INT3 = auto()
-    INT4 = auto()
-    INT5 = auto()
-    INT6 = auto()
-    INT7 = auto()
-    INT8 = auto()
-    INT9 = auto()
-    INT10 = auto()
-    INT11 = auto()
-    INT12 = auto()
-    INT13 = auto()
-    INT14 = auto()
-    INT15 = auto()
-    INT16 = auto()
-    INT17 = auto()
-    INT18 = auto()
-    INT19 = auto()
-    INT20 = auto()
-    INT21 = auto()
-    INT22 = auto()
-    INT23 = auto()
-    INT24 = auto()
-    INT25 = auto()
-    INT26 = auto()
-    INT27 = auto()
-    INT28 = auto()
-    INT29 = auto()
-    INT30 = auto()
-    INT31 = auto()
-    INT32 = auto()
-    INT64 = auto()
-    FLOAT32 = auto()
-
+    @abstractmethod
     def bitwidth(self):
-        """Returns the number of bits required for this DataType."""
+        "Returns the number of bits required for this DataType."
+        pass
 
-        if self.name.startswith("UINT"):
-            return int(self.name.strip("UINT"))
-        elif self.name.startswith("INT"):
-            return int(self.name.strip("INT"))
-        elif "FLOAT" in self.name:
-            return int(self.name.strip("FLOAT"))
-        elif self.name in ["BINARY", "BIPOLAR"]:
-            return 1
-        elif self.name == "TERNARY":
-            return 2
-        else:
-            raise Exception("Unrecognized data type: %s" % self.name)
-
+    @abstractmethod
     def min(self):
-        """Returns the smallest possible value allowed by this DataType."""
+        "Returns the smallest possible value allowed by this DataType."
+        pass
 
-        if self.name.startswith("UINT") or self.name == "BINARY":
-            return 0
-        elif self.name.startswith("INT"):
-            return -(2 ** (self.bitwidth() - 1))
-        elif self.name == "FLOAT32":
-            return np.finfo(np.float32).min
-        elif self.name == "BIPOLAR":
-            return -1
-        elif self.name == "TERNARY":
-            return -1
-        else:
-            raise Exception("Unrecognized data type: %s" % self.name)
-
+    @abstractmethod
     def max(self):
-        """Returns the largest possible value allowed by this DataType."""
+        "Returns the largest possible value allowed by this DataType."
+        pass
 
-        if self.name.startswith("UINT"):
-            return (2 ** (self.bitwidth())) - 1
-        elif self.name == "BINARY":
-            return +1
-        elif self.name.startswith("INT"):
-            return (2 ** (self.bitwidth() - 1)) - 1
-        elif self.name == "FLOAT32":
-            return np.finfo(np.float32).max
-        elif self.name == "BIPOLAR":
-            return +1
-        elif self.name == "TERNARY":
-            return +1
-        else:
-            raise Exception("Unrecognized data type: %s" % self.name)
-
+    @abstractmethod
     def allowed(self, value):
         """Check whether given value is allowed for this DataType.
 
         * value (float32): value to be checked"""
+        pass
 
-        if "FLOAT" in self.name:
-            return True
-        elif "INT" in self.name:
-            return (
-                (self.min() <= value)
-                and (value <= self.max())
-                and float(value).is_integer()
-            )
-        elif self.name == "BINARY":
-            return value in [0, 1]
-        elif self.name == "BIPOLAR":
-            return value in [-1, +1]
-        elif self.name == "TERNARY":
-            return value in [-1, 0, +1]
-        else:
-            raise Exception("Unrecognized data type: %s" % self.name)
-
+    @abstractmethod
     def get_num_possible_values(self):
         """Returns the number of possible values this DataType can take. Only
         implemented for integer types for now."""
-        assert self.is_integer(), """This function only works for integers for now,
-        not for the DataType you used this function with."""
-        if "INT" in self.name:
-            return abs(self.min()) + abs(self.max()) + 1
-        elif self.name == "BINARY" or self.name == "BIPOLAR":
-            return 2
-        elif self.name == "TERNARY":
-            return 3
+        pass
 
+    @abstractmethod
+    def is_integer(self):
+        "Returns whether this DataType represents integer values only."
+        pass
+
+    @abstractmethod
+    def is_fixed_point(self):
+        "Returns whether this DataType represent fixed-point values only."
+        pass
+
+    @abstractmethod
+    def get_hls_datatype_str(self):
+        "Returns the corresponding Vivado HLS datatype name."
+        pass
+
+    @abstractmethod
+    def to_numpy_dt(self):
+        "Return an appropriate numpy datatype that can represent this FINN DataType."
+        pass
+
+    @abstractmethod
+    def get_canonical_name(self):
+        "Return a canonical string representation of this FINN DataType."
+
+
+class FloatType(BaseDataType):
+    def bitwidth(self):
+        return 32
+
+    def min(self):
+        return np.finfo(np.float32).min
+
+    def max(self):
+        return np.finfo(np.float32).max
+
+    def allowed(self, value):
+        return True
+
+    def get_num_possible_values(self):
+        raise Exception("Undefined for FloatType")
+
+    def is_integer(self):
+        return False
+
+    def is_fixed_point(self):
+        return False
+
+    def get_hls_datatype_str(self):
+        return "float"
+
+    def to_numpy_dt(self):
+        return np.float32
+
+    def get_canonical_name(self):
+        return "FLOAT32"
+
+
+class IntType(BaseDataType):
+    def __init__(self, bitwidth, signed):
+        super().__init__()
+        self._bitwidth = bitwidth
+        self._signed = signed
+
+    def bitwidth(self):
+        return self._bitwidth
+
+    def min(self):
+        unsigned_min = 0
+        signed_min = -(2 ** (self.bitwidth() - 1))
+        return signed_min if self._signed else unsigned_min
+
+    def max(self):
+        unsigned_max = (2 ** (self.bitwidth())) - 1
+        signed_max = (2 ** (self.bitwidth() - 1)) - 1
+        return signed_max if self._signed else unsigned_max
+
+    def allowed(self, value):
+        return (
+            (self.min() <= value)
+            and (value <= self.max())
+            and float(value).is_integer()
+        )
+
+    def get_num_possible_values(self):
+        return abs(self.min()) + abs(self.max()) + 1
+
+    def is_integer(self):
+        return True
+
+    def is_fixed_point(self):
+        return False
+
+    def get_hls_datatype_str(self):
+        if self.signed():
+            return "ap_int<%d>" % self.bitwidth()
+        else:
+            return "ap_uint<%d>" % self.bitwidth()
+
+    def to_numpy_dt(self):
+        if self.bitwidth() <= 8:
+            return np.int8 if self.signed() else np.uint8
+        elif self.bitwidth() <= 16:
+            return np.int16 if self.signed() else np.uint16
+        elif self.bitwidth() <= 32:
+            return np.int32 if self.signed() else np.uint32
+        elif self.bitwidth() <= 64:
+            return np.int64 if self.signed() else np.uint64
+        else:
+            raise Exception("Unknown numpy dtype for " + str(self))
+
+    def get_canonical_name(self):
+        if self.bitwidth() == 1 and (not self.signed()):
+            return "BINARY"
+        else:
+            prefix = "INT" if self.signed() else "UINT"
+            return prefix + str(self.bitwidth())
+
+
+class BipolarType(BaseDataType):
+    def bitwidth(self):
+        return 1
+
+    def min(self):
+        return -1
+
+    def max(self):
+        return +1
+
+    def allowed(self, value):
+        return value in [-1, +1]
+
+    def get_num_possible_values(self):
+        return 2
+
+    def is_integer(self):
+        return True
+
+    def is_fixed_point(self):
+        return False
+
+    def get_hls_datatype_str(self):
+        return "ap_int<1>"
+
+    def to_numpy_dt(self):
+        return np.int8
+
+    def get_canonical_name(self):
+        return "BIPOLAR"
+
+
+class TernaryType(BaseDataType):
+    def bitwidth(self):
+        return 2
+
+    def min(self):
+        return -1
+
+    def max(self):
+        return +1
+
+    def allowed(self, value):
+        return value in [-1, 0, +1]
+
+    def get_num_possible_values(self):
+        return 3
+
+    def is_integer(self):
+        return True
+
+    def is_fixed_point(self):
+        return False
+
+    def get_hls_datatype_str(self):
+        return "ap_int<2>"
+
+    def to_numpy_dt(self):
+        return np.int8
+
+    def get_canonical_name(self):
+        return "TERNARY"
+
+
+class FixedPointType(IntType):
+    def __init__(self, bitwidth, intwidth):
+        super().__init__(bitwidth=bitwidth, signed=True)
+        assert intwidth < bitwidth, "FixedPointType violates intwidth < bitwidth"
+        self._intwidth = intwidth
+
+    def int_bits(self):
+        return self._intwidth
+
+    def frac_bits(self):
+        return self.bitwidth() - self.int_bits()
+
+    def scale_factor(self):
+        return 2 ** -(self.frac_bits())
+
+    def min(self):
+        return super().min() * self.scale_factor()
+
+    def max(self):
+        return super().max() * self.scale_factor()
+
+    def allowed(self, value):
+        int_value = value / self.scale_factor()
+        return IntType(self._bitwidth, True).allowed(int_value)
+
+    def is_integer(self):
+        return False
+
+    def is_fixed_point(self):
+        return True
+
+    def get_hls_datatype_str(self):
+        return "ap_fixed<%d, %d>" % (self.bitwidth(), self.int_bits())
+
+    def to_numpy_dt(self):
+        return np.float32
+
+    def get_canonical_name(self):
+        return "FIXED<%d,%d>" % (self.bitwidth(), self.int_bits())
+
+
+def resolve_datatype(name):
+    _special_types = {
+        "BINARY": IntType(1, False),
+        "BIPOLAR": BipolarType(),
+        "TERNARY": TernaryType(),
+        "FLOAT32": FloatType(),
+    }
+    if name in _special_types.keys():
+        return _special_types[name]
+    elif name.startswith("UINT"):
+        bitwidth = int(name.replace("UINT", ""))
+        return IntType(bitwidth, False)
+    elif name.startswith("INT"):
+        bitwidth = int(name.replace("INT", ""))
+        return IntType(bitwidth, True)
+    elif name.startswith("FIXED"):
+        name = name.replace("FIXED<", "")
+        name = name.replace(">", "")
+        nums = name.split(",")
+        bitwidth = int(nums[0].strip())
+        intwidth = int(nums[1].strip())
+        return FixedPointType(bitwidth, intwidth)
+    else:
+        raise KeyError("Could not resolve DataType " + name)
+
+
+class DataTypeMeta(EnumMeta):
+    def __getitem__(self, name):
+        return resolve_datatype(name)
+
+
+class DataType(Enum, metaclass=DataTypeMeta):
+    """Enum class that contains FINN data types to set the quantization annotation.
+    ONNX does not support data types smaller than 8-bit integers, whereas in FINN we are
+    interested in smaller integers down to ternary and bipolar."""
+
+    @staticmethod
+    def get_accumulator_dt_cands():
+        cands = ["BINARY"]
+        cands += ["UINT%d" % (x + 1) for x in range(64)]
+        cands += ["BIPOLAR", "TERNARY"]
+        cands += ["INT%d" % (x + 1) for x in range(64)]
+        return cands
+
+    @staticmethod
     def get_smallest_possible(value):
         """Returns smallest (fewest bits) possible DataType that can represent
         value. Prefers unsigned integers where possible."""
         if not int(value) == value:
             return DataType["FLOAT32"]
-        for k in DataType.__members__:
-            dt = DataType[k]
+        cands = DataType.get_accumulator_dt_cands()
+        for cand in cands:
+            dt = DataType[cand]
             if (dt.min() <= value) and (value <= dt.max()):
                 return dt
-
-    def signed(self):
-        """Returns whether this DataType can represent negative numbers."""
-        return self.min() < 0
-
-    def is_integer(self):
-        """Returns whether this DataType represents integer values only."""
-        # only FLOAT32 is noninteger for now
-        return self != DataType.FLOAT32
-
-    def get_hls_datatype_str(self):
-        """Returns the corresponding Vivado HLS datatype name."""
-        if self.is_integer():
-            if self.signed():
-                return "ap_int<%d>" % self.bitwidth()
-            else:
-                return "ap_uint<%d>" % self.bitwidth()
-        else:
-            return "float"
-
-    def to_numpy_dt(self):
-        "For 8/16/32/64-bit types, return equivalent NumPy dtype"
-
-        if self.is_integer():
-            if self.bitwidth() <= 8:
-                return np.int8 if self.signed() else np.uint8
-            elif self.bitwidth() <= 16:
-                return np.int16 if self.signed() else np.uint16
-            elif self.bitwidth() <= 32:
-                return np.int32 if self.signed() else np.uint32
-            elif self.bitwidth() <= 64:
-                return np.int64 if self.signed() else np.uint64
-            else:
-                raise Exception("Unknown numpy dtype for " + str(self))
-        else:
-            return np.float32
+        raise Exception("Could not find a suitable int datatype for " + str(value))

--- a/src/finn/core/modelwrapper.py
+++ b/src/finn/core/modelwrapper.py
@@ -217,7 +217,11 @@ class ModelWrapper:
         vi_names += [(x.name, x) for x in graph.output]
         vi_names += [(x.name, x) for x in graph.value_info]
         try:
-            vi_ind = [x[0] for x in vi_names].index(tensor_name)
+            vi_t_names = [x[0] for x in vi_names]
+            assert vi_t_names.count(tensor_name) <= 1, (
+                "Multiple ValueInfoProto found for " + tensor_name
+            )
+            vi_ind = vi_t_names.index(tensor_name)
             vi = vi_names[vi_ind][1]
             return vi
         except ValueError:
@@ -230,7 +234,11 @@ class ModelWrapper:
         vi_names += [(x.name, x) for x in graph.output]
         vi_names += [(x.name, x) for x in graph.value_info]
         try:
-            vi_ind = [x[0] for x in vi_names].index(tensor_name)
+            vi_t_names = [x[0] for x in vi_names]
+            assert vi_t_names.count(tensor_name) <= 1, (
+                "Multiple ValueInfoProto found for " + tensor_name
+            )
+            vi_ind = vi_t_names.index(tensor_name)
             vi = vi_names[vi_ind][1]
             dims = [x.dim_value for x in vi.type.tensor_type.shape.dim]
             return dims
@@ -240,6 +248,8 @@ class ModelWrapper:
     def set_tensor_shape(self, tensor_name, tensor_shape, dtype=TensorProto.FLOAT):
         """Assigns shape in ValueInfoProto for tensor with given name."""
         new_vi = oh.make_tensor_value_info(tensor_name, dtype, tensor_shape)
+        # call get_tensor_shape to catch multiple ValueInfoProto cases
+        self.get_tensor_shape(tensor_name)
         # find what container tis tensor's ValueInfo lives in
         # if not found anywhere, we assume it's a new value_info
         target_container = self.graph.value_info

--- a/src/finn/core/modelwrapper.py
+++ b/src/finn/core/modelwrapper.py
@@ -345,13 +345,17 @@ class ModelWrapper:
                 visit_list.append(current_producer)
                 if found:
                     return visit_list
-                else:
+                elif len(current_producer.input) > 0:
                     current_tensor = current_producer.input[0]
+                else:
+                    return None
 
     def find_consumer(self, tensor_name):
         """Finds and returns the node that consumes the tensor with given name.
         Currently only works for linear graphs."""
-        all_inputs = [x.input[0] for x in self._model_proto.graph.node]
+        all_inputs = [
+            x.input[0] for x in self._model_proto.graph.node if len(x.input) > 0
+        ]
         try:
             consumer_ind = all_inputs.index(tensor_name)
             return self._model_proto.graph.node[consumer_ind]

--- a/src/finn/core/modelwrapper.py
+++ b/src/finn/core/modelwrapper.py
@@ -197,13 +197,16 @@ class ModelWrapper:
                 ret.quant_parameter_tensor_names, "finn_datatype", "key"
             )
             if ret_dt is not None:
-                ret_dt.value = datatype.name
-            else:
+                if datatype is None:
+                    ret_dt.Clear()
+                else:
+                    ret_dt.value = datatype.name
+            elif datatype is not None:
                 dt = onnx.StringStringEntryProto()
                 dt.key = "finn_datatype"
                 dt.value = datatype.name
                 ret.quant_parameter_tensor_names.append(dt)
-        else:
+        elif datatype is not None:
             qa = onnx.TensorAnnotation()
             dt = onnx.StringStringEntryProto()
             dt.key = "finn_datatype"

--- a/src/finn/core/modelwrapper.py
+++ b/src/finn/core/modelwrapper.py
@@ -58,7 +58,9 @@ class ModelWrapper:
         is made internally.
         """
         if isinstance(onnx_model_proto, str):
-            assert os.path.isfile(onnx_model_proto)
+            assert os.path.isfile(
+                onnx_model_proto
+            ), f"File not found: {onnx_model_proto}"
             self._model_proto = onnx.load(onnx_model_proto)
         elif isinstance(onnx_model_proto, bytes):
             self._model_proto = onnx.load_from_string(onnx_model_proto)

--- a/src/finn/core/modelwrapper.py
+++ b/src/finn/core/modelwrapper.py
@@ -353,14 +353,10 @@ class ModelWrapper:
     def find_consumer(self, tensor_name):
         """Finds and returns the node that consumes the tensor with given name.
         Currently only works for linear graphs."""
-        all_inputs = [
-            x.input[0] for x in self._model_proto.graph.node if len(x.input) > 0
-        ]
-        try:
-            consumer_ind = all_inputs.index(tensor_name)
-            return self._model_proto.graph.node[consumer_ind]
-        except ValueError:
-            return None
+        for node in self.graph.node:
+            if len(node.input) > 0 and node.input[0] == tensor_name:
+                return node
+        return None
 
     def find_consumers(self, tensor_name):
         """Finds and returns a list of the nodes that consume tensor with

--- a/src/finn/core/modelwrapper.py
+++ b/src/finn/core/modelwrapper.py
@@ -546,13 +546,7 @@ class ModelWrapper:
     def set_tensor_layout(self, tensor_name, data_layout):
         """Sets the data layout annotation of tensor with given name. See
         get_tensor_layout for examples."""
-        tensor_shape = self.get_tensor_shape(tensor_name)
         assert type(data_layout) == list, "data_layout must be a list"
-        if tensor_shape is not None:
-            assert len(tensor_shape) == len(
-                data_layout
-            ), """Mismatch between number
-            of dimensions of tensor shape and data layout annotation."""
         graph = self._model_proto.graph
         qnt_annotations = graph.quantization_annotation
         ret = util.get_by_name(qnt_annotations, tensor_name, "tensor_name")

--- a/src/finn/core/onnx_exec.py
+++ b/src/finn/core/onnx_exec.py
@@ -51,7 +51,7 @@ def execute_node(node, context, graph, return_full_exec_context=False):
 
     Input/output provided via context."""
 
-    if node.op_type == "GenericPartition":
+    if node.op_type in ["GenericPartition", "StreamingDataflowPartition"]:
         partition_node = getCustomOp(node)
         model = ModelWrapper(partition_node.get_nodeattr("model"))
         inp_ctx = dict(filter(lambda x: x[0] in node.input, context.items()))
@@ -70,32 +70,6 @@ def execute_node(node, context, graph, return_full_exec_context=False):
         if return_full_exec_context:
             for tname in ret.keys():
                 if tname not in [x.name for x in model.graph.output]:
-                    context[node.name + "_" + tname] = ret[tname]
-    elif node.op_type == "StreamingDataflowPartition":
-        sdp_node = getCustomOp(node)
-        model = ModelWrapper(sdp_node.get_nodeattr("model"))
-        inp_ctx = dict(filter(lambda x: x[0] in node.input, context.items()))
-        # input may have been renamed in partition
-        assert len(inp_ctx) == 1
-        old_iname = node.input[0]
-        new_iname = model.graph.input[0].name
-        if old_iname != new_iname:
-            inp_ctx[new_iname] = inp_ctx[old_iname]
-            del inp_ctx[old_iname]
-        ret = execute_onnx(model, inp_ctx, return_full_exec_context)
-        # if the model was in ip-stitched rtlsim mode, may get annotation
-        # for numbet of elapsed cycles, save again
-        if model.get_metadata_prop("exec_mode") == "rtlsim":
-            model.save(sdp_node.get_nodeattr("model"))
-        # output may have been renamed in partition
-        assert len(model.graph.output) == 1
-        node_oname = node.output[0]
-        model_oname = model.graph.output[0].name
-        context[node_oname] = ret[model_oname]
-        # prefix and insert exec context entries
-        if return_full_exec_context:
-            for tname in ret.keys():
-                if tname != model_oname:
                     context[node.name + "_" + tname] = ret[tname]
     else:
         if is_finn_op(node.domain):

--- a/src/finn/core/onnx_exec.py
+++ b/src/finn/core/onnx_exec.py
@@ -108,7 +108,9 @@ def execute_node(node, context, graph, return_full_exec_context=False):
             # graph.value_info as well as graph.output or graph.input
             # nodes with multiple outputs that are a mix of value_info and
             # input/outputs may get them reordered below
+            # note: a node's input may (also) be a top-level input or output
             node_inputs = list(filter(lambda x: x.name in node.input, graph.input))
+            node_inputs += list(filter(lambda x: x.name in node.input, graph.output))
             node_inputs += list(
                 filter(lambda x: x.name in node.input, graph.value_info)
             )

--- a/src/finn/custom_op/base.py
+++ b/src/finn/custom_op/base.py
@@ -131,6 +131,19 @@ class CustomOp(ABC):
         except KeyError:
             raise AttributeError("Op has no such attribute: " + name)
 
+    def make_const_shape_op(self, shape):
+        """Return an ONNX node that generates the desired output shape for
+        shape inference."""
+        return helper.make_node(
+            "RandomNormal",
+            inputs=[],
+            outputs=[self.onnx_node.output[0]],
+            mean=0.0,
+            scale=1.0,
+            dtype=1,
+            shape=list(shape),
+        )
+
     @abstractmethod
     def get_nodeattr_types(self):
         """Returns a dict of permitted attributes for node, where:

--- a/src/finn/custom_op/general/__init__.py
+++ b/src/finn/custom_op/general/__init__.py
@@ -26,12 +26,15 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from finn.custom_op.general.bipolar_quant import BipolarQuant
 from finn.custom_op.general.debugmarker import DebugMarker
 from finn.custom_op.general.genericpartition import GenericPartition
 from finn.custom_op.general.im2col import Im2Col
 from finn.custom_op.general.maxpoolnhwc import MaxPoolNHWC
 from finn.custom_op.general.multithreshold import MultiThreshold
+from finn.custom_op.general.quant import Quant
 from finn.custom_op.general.quantavgpool2d import QuantAvgPool2d
+from finn.custom_op.general.trunc import Trunc
 from finn.custom_op.general.xnorpopcount import XnorPopcountMatMul
 
 custom_op = dict()
@@ -43,3 +46,6 @@ custom_op["GenericPartition"] = GenericPartition
 custom_op["MultiThreshold"] = MultiThreshold
 custom_op["XnorPopcountMatMul"] = XnorPopcountMatMul
 custom_op["Im2Col"] = Im2Col
+custom_op["Quant"] = Quant
+custom_op["Trunc"] = Trunc
+custom_op["BipolarQuant"] = BipolarQuant

--- a/src/finn/custom_op/general/bipolar_quant.py
+++ b/src/finn/custom_op/general/bipolar_quant.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2021 Xilinx, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of Xilinx nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import numpy as np
+import onnx.helper as helper
+
+from finn.core.datatype import DataType
+from finn.custom_op.base import CustomOp
+
+
+def binary_quant(inp_tensor, scale):
+    # ToDo: Update this link, when the PR gets merged
+    # Port of IntQuant class from Brevitas: https://bit.ly/2S6qvZJ
+
+    # Quantizing
+    y_int = inp_tensor
+    y_ones = np.ones(y_int.shape, dtype=y_int.dtype)
+    y_int = np.where(y_int >= 0.0, y_ones, -y_ones)
+    # Scaling
+    out_tensor = y_int * scale
+
+    return out_tensor
+
+
+class BipolarQuant(CustomOp):
+    """Bipolar quantization operation for QONNX. Takes four inputs:
+    - input tensor to quantize
+    - the scale
+
+    The output is a tensor of the same shape as the input tensor, with quantized
+    values.
+    """
+
+    def get_nodeattr_types(self):
+        return dict()
+
+    def make_shape_compatible_op(self, model):
+        node = self.onnx_node
+        return helper.make_node("Identity", [node.input[0]], [node.output[0]])
+
+    def get_integer_datatype(self, model):
+        return DataType["BIPOLAR"]
+
+    def get_output_dtype(self, model):
+        node = self.onnx_node
+        # scale must be read from initializers
+        scale = model.get_initializer(node.input[1])
+        # determine the FINN DataType
+        unit_scale = np.all(scale == 1.0)
+        if unit_scale:
+            finn_dt = self.get_integer_datatype(model)
+        else:
+            finn_dt = DataType["FLOAT32"]
+
+        return finn_dt
+
+    def infer_node_datatype(self, model):
+        try:
+            finn_dt = self.get_output_dtype(model)
+        except AssertionError:
+            finn_dt = DataType["FLOAT32"]
+        node = self.onnx_node
+        model.set_tensor_datatype(node.output[0], finn_dt)
+
+    def execute_node(self, context, graph):
+        node = self.onnx_node
+        # save inputs
+        inp_tensor = context[node.input[0]]
+        scale = context[node.input[1]]
+        # calculate output
+        ret = binary_quant(inp_tensor, scale)
+        # ensure output is ndarray (even if 0d)
+        # since numpy silently flattens 0d arrays to scalars
+        # more: https://github.com/numpy/numpy/issues/13105
+        if not isinstance(ret, np.ndarray):
+            ret = np.asarray(ret)
+        # set context according to output name
+        context[node.output[0]] = ret
+
+    def verify_node(self):
+        pass

--- a/src/finn/custom_op/general/im2col.py
+++ b/src/finn/custom_op/general/im2col.py
@@ -1,5 +1,4 @@
 import numpy as np
-from onnx import helper
 
 import finn.util.basic as util
 from finn.core.datatype import DataType
@@ -184,11 +183,8 @@ class Im2Col(CustomOp):
         ofm_dim_h = compute_conv_output_dim(ifm_dim_h, k_h, stride_h, pad_h, dilation_h)
         ofm_dim_w = compute_conv_output_dim(ifm_dim_w, k_w, stride_w, pad_w, dilation_w)
 
-        return helper.make_node(
-            "RandomNormal",
-            inputs=[],
-            outputs=[self.onnx_node.output[0]],
-            shape=[1, ofm_dim_h, ofm_dim_w, k_h * k_w * ifm_ch],
+        return super().make_const_shape_op(
+            [1, ofm_dim_h, ofm_dim_w, k_h * k_w * ifm_ch]
         )
 
     def infer_node_datatype(self, model):

--- a/src/finn/custom_op/general/im2col.py
+++ b/src/finn/custom_op/general/im2col.py
@@ -1,5 +1,5 @@
 import numpy as np
-from onnx import TensorProto, helper
+from onnx import helper
 
 import finn.util.basic as util
 from finn.core.datatype import DataType
@@ -184,20 +184,11 @@ class Im2Col(CustomOp):
         ofm_dim_h = compute_conv_output_dim(ifm_dim_h, k_h, stride_h, pad_h, dilation_h)
         ofm_dim_w = compute_conv_output_dim(ifm_dim_w, k_w, stride_w, pad_w, dilation_w)
 
-        # implement tensor with correct shape
-        values = np.random.randn(1, ofm_dim_h, ofm_dim_w, k_h * k_w * ifm_ch).astype(
-            np.float32
-        )
         return helper.make_node(
-            "Constant",
+            "RandomNormal",
             inputs=[],
             outputs=[self.onnx_node.output[0]],
-            value=helper.make_tensor(
-                name="const_tensor",
-                data_type=TensorProto.FLOAT,
-                dims=values.shape,
-                vals=values.flatten().astype(float),
-            ),
+            shape=[1, ofm_dim_h, ofm_dim_w, k_h * k_w * ifm_ch],
         )
 
     def infer_node_datatype(self, model):

--- a/src/finn/custom_op/general/maxpoolnhwc.py
+++ b/src/finn/custom_op/general/maxpoolnhwc.py
@@ -63,12 +63,7 @@ class MaxPoolNHWC(CustomOp):
         ho = compute_pool_output_dim(hi, kernel_shape[0], strides[0], pads[0])
         wo = compute_pool_output_dim(wi, kernel_shape[1], strides[1], pads[2])
         oshape = (n, ho, wo, c)
-        return helper.make_node(
-            "RandomNormal",
-            inputs=[],
-            outputs=[self.onnx_node.output[0]],
-            shape=list(oshape),
-        )
+        return super().make_const_shape_op(oshape)
 
     def infer_node_datatype(self, model):
         node = self.onnx_node

--- a/src/finn/custom_op/general/maxpoolnhwc.py
+++ b/src/finn/custom_op/general/maxpoolnhwc.py
@@ -63,18 +63,11 @@ class MaxPoolNHWC(CustomOp):
         ho = compute_pool_output_dim(hi, kernel_shape[0], strides[0], pads[0])
         wo = compute_pool_output_dim(wi, kernel_shape[1], strides[1], pads[2])
         oshape = (n, ho, wo, c)
-        # implement tensor with correct shape
-        values = np.random.randn(*oshape).astype(np.float32)
         return helper.make_node(
-            "Constant",
+            "RandomNormal",
             inputs=[],
             outputs=[self.onnx_node.output[0]],
-            value=helper.make_tensor(
-                name="const_tensor",
-                data_type=TensorProto.FLOAT,
-                dims=values.shape,
-                vals=values.flatten().astype(float),
-            ),
+            shape=list(oshape),
         )
 
     def infer_node_datatype(self, model):

--- a/src/finn/custom_op/general/multithreshold.py
+++ b/src/finn/custom_op/general/multithreshold.py
@@ -102,7 +102,17 @@ class MultiThreshold(CustomOp):
     def infer_node_datatype(self, model):
         node = self.onnx_node
         odt = self.get_nodeattr("out_dtype")
-        model.set_tensor_datatype(node.output[0], DataType[odt])
+        is_float = False
+        scale = self.get_nodeattr("out_scale")
+        bias = self.get_nodeattr("out_bias")
+        if scale is not None and (int(scale) != scale):
+            is_float = True
+        if bias is not None and (int(bias) != bias):
+            is_float = True
+        if is_float:
+            model.set_tensor_datatype(node.output[0], DataType["FLOAT32"])
+        else:
+            model.set_tensor_datatype(node.output[0], DataType[odt])
 
     def execute_node(self, context, graph):
         node = self.onnx_node

--- a/src/finn/custom_op/general/quant.py
+++ b/src/finn/custom_op/general/quant.py
@@ -1,0 +1,242 @@
+# Copyright (c) 2021 Xilinx, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of Xilinx nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import numpy as np
+import onnx.helper as helper
+
+from finn.core.datatype import DataType
+from finn.custom_op.base import CustomOp
+
+
+def min_int(signed: bool, narrow_range: bool, bit_width: int) -> int:
+    """Compute the minimum integer representable by a given number of bits.
+    Args:
+        signed (bool): Indicates whether the represented integer is signed or not.
+        narrow_range (bool): Indicates whether to narrow the minimum value
+        represented by 1.
+        bit_width (int): Number of bits available for the representation.
+    Returns:
+        int: Maximum unsigned integer that can be represented according to
+        the input arguments.
+    Examples:
+        >>> min_int(signed=True, narrow_range=True, bit_width=8)
+        int(-127)
+        >>> min_int(signed=False, narrow_range=True, bit_width=8)
+        int(0)
+        >>> min_int(signed=True, narrow_range=False, bit_width=8)
+        int(-128)
+        >>> min_int(signed=False, narrow_range=False, bit_width=8)
+        int(0)
+    """
+    if signed and narrow_range:
+        value = -(2 ** (bit_width - 1)) + 1
+    elif signed and not narrow_range:
+        value = -(2 ** (bit_width - 1))
+    else:
+        value = 0 * bit_width
+    return value
+
+
+def max_int(signed: bool, narrow_range: bool, bit_width: int) -> int:
+    """Compute the maximum integer representable by a given number of bits.
+    Args:
+        signed (bool): Indicates whether the represented integer is signed or not.
+        narrow_range (bool): Indicates whether to narrow the maximum unsigned value
+        represented by 1.
+        bit_width (int): Number of bits available for the representation.
+    Returns:
+        Tensor: Maximum integer that can be represented according to
+        the input arguments.
+    Examples:
+        >>> max_int(signed=True, narrow_range=True, bit_width=8)
+        int(127)
+        >>> max_int(signed=False, narrow_range=True, bit_width=8)
+        int(254)
+        >>> max_int(signed=True, narrow_range=False, bit_width=8)
+        int(127)
+        >>> max_int(signed=False, narrow_range=False, bit_width=8)
+        int(255)
+    """
+    if not signed and not narrow_range:
+        value = (2 ** bit_width) - 1
+    elif not signed and narrow_range:
+        value = (2 ** bit_width) - 2
+    else:
+        value = (2 ** (bit_width - 1)) - 1
+    return value
+
+
+def quant(inp_tensor, scale, zeropt, bitwidth, signed, narrow, rounding_mode):
+    # ToDo: Update this link, when the PR gets merged
+    # Port of IntQuant class from Brevitas: https://bit.ly/2S6qvZJ
+
+    # Scaling
+    y_int = inp_tensor / scale
+    y_int = y_int + zeropt
+    if bitwidth == 1 and signed:
+        # BUG: 1-bit Quant ops currently not exported correctly
+        # manually convert to bipolar values
+        y_ones = np.ones(y_int.shape, dtype=y_int.dtype)
+        y_int = np.where(y_int >= 0.0, y_ones, -y_ones)
+    else:
+        # Clamping
+        min_int_val = min_int(signed, narrow, bitwidth)
+        max_int_val = max_int(signed, narrow, bitwidth)
+        y_int = np.where(y_int > max_int_val, max_int_val.astype(y_int.dtype), y_int)
+        y_int = np.where(y_int < min_int_val, min_int_val.astype(y_int.dtype), y_int)
+        # Rounding
+        rounding_fx = resolve_rounding_mode(rounding_mode)
+        y_int = rounding_fx(y_int)
+    # Re-scaling
+    out_tensor = y_int - zeropt
+    out_tensor = out_tensor * scale
+
+    return out_tensor
+
+
+def resolve_rounding_mode(mode_string):
+    """Resolve the rounding mode string of Quant and Trunc ops
+    to the corresponding numpy functions."""
+    if mode_string == "ROUND":
+        return np.round
+    elif mode_string == "CEIL":
+        return np.ceil
+    elif mode_string == "FLOOR":
+        return np.floor
+    else:
+        raise ValueError(f"Could not resolve rounding mode called: {mode_string}")
+
+
+class Quant(CustomOp):
+    """Generic quantization operation for QONNX. Takes four inputs:
+    - input tensor to quantize
+    - the scale
+    - the zero-point
+    - the bit-width
+
+    The output is a tensor of the same shape as the input tensor, with quantized
+    values.
+    """
+
+    def get_nodeattr_types(self):
+        return {
+            # whether the quantization interval should be signed or not
+            # (e.g. at 8b unsigned=[0, 255] vs signed=[-128, 127])
+            "signed": ("i", True, 1),
+            # when signed=1, whether to use narrow range or not
+            # (e.g. at 8b regular=[-128, 127] vs narrow=[-127, 127])
+            "narrow": ("i", True, 1),
+            # The rounding mode, which is used for the quant function
+            # ToDo: This should be required (True) instead of optional (False)
+            "rounding_mode": ("s", False, "ROUND"),
+        }
+
+    def make_shape_compatible_op(self, model):
+        node = self.onnx_node
+        return helper.make_node("Identity", [node.input[0]], [node.output[0]])
+
+    def get_integer_datatype(self, model):
+        signed = self.get_nodeattr("signed")
+        bit_width = model.get_initializer(self.onnx_node.input[3])
+        bit_width = int(bit_width)
+        if bit_width == 1:
+            if signed:
+                finn_dt = DataType["BIPOLAR"]
+            else:
+                finn_dt = DataType["BINARY"]
+        else:
+            if signed:
+                finn_dt = DataType["INT" + str(bit_width)]
+            else:
+                finn_dt = DataType["UINT" + str(bit_width)]
+        return finn_dt
+
+    def get_output_dtype(self, model):
+        node = self.onnx_node
+        # scale, zero-point and bitwidth must be read from initializers
+        scale = model.get_initializer(node.input[1])
+        zeropt = model.get_initializer(node.input[2])
+        bitwidth = model.get_initializer(node.input[3])
+        assert scale is not None, "Found unspecified scale for Quant node: " + str(node)
+        assert (
+            zeropt is not None
+        ), "Found unspecified zero point for Quant node: " + str(node)
+        assert (
+            bitwidth is not None
+        ), "Found unspecified bitwidth for Quant node: " + str(node)
+        # extract the bitwidth (assume scalar)
+        assert bitwidth.ndim == 0, "Bitwidth must be scalar for Quant node: " + str(
+            node
+        )
+        bitwidth = bitwidth.item()
+        assert (
+            int(bitwidth) == bitwidth
+        ), "Bitwidth must be integer for Quant node: " + str(node)
+        bitwidth = int(bitwidth)
+        # determine the FINN DataType
+        unit_scale = np.all(scale == 1.0)
+        zero_zeropt = np.all(zeropt == 0.0)
+        assert zero_zeropt, "Only zero_point=0 Quant nodes supported for now"
+        if unit_scale and zero_zeropt:
+            finn_dt = self.get_integer_datatype(model)
+        else:
+            finn_dt = DataType["FLOAT32"]
+
+        return finn_dt
+
+    def infer_node_datatype(self, model):
+        try:
+            finn_dt = self.get_output_dtype(model)
+        except AssertionError:
+            finn_dt = DataType["FLOAT32"]
+        node = self.onnx_node
+        model.set_tensor_datatype(node.output[0], finn_dt)
+
+    def execute_node(self, context, graph):
+        node = self.onnx_node
+        # save inputs
+        inp_tensor = context[node.input[0]]
+        scale = context[node.input[1]]
+        zeropt = context[node.input[2]]
+        bitwidth = context[node.input[3]]
+        # save attributes
+        signed = self.get_nodeattr("signed")
+        narrow = self.get_nodeattr("narrow")
+        rounding_mode = self.get_nodeattr("rounding_mode")
+        # calculate output
+        ret = quant(inp_tensor, scale, zeropt, bitwidth, signed, narrow, rounding_mode)
+        # ensure output is ndarray (even if 0d)
+        # since numpy silently flattens 0d arrays to scalars
+        # more: https://github.com/numpy/numpy/issues/13105
+        if not isinstance(ret, np.ndarray):
+            ret = np.asarray(ret)
+        # set context according to output name
+        context[node.output[0]] = ret
+
+    def verify_node(self):
+        pass

--- a/src/finn/custom_op/general/quantavgpool2d.py
+++ b/src/finn/custom_op/general/quantavgpool2d.py
@@ -71,12 +71,7 @@ class QuantAvgPool2d(CustomOp):
             ho = compute_pool_output_dim(hi, k, s)
             wo = compute_pool_output_dim(wi, k, s)
             oshape = (n, ho, wo, c)
-            return helper.make_node(
-                "RandomNormal",
-                inputs=[],
-                outputs=[node.output[0]],
-                shape=list(oshape),
-            )
+            return super().make_const_shape_op(oshape)
 
         else:
             raise Exception(

--- a/src/finn/custom_op/general/quantavgpool2d.py
+++ b/src/finn/custom_op/general/quantavgpool2d.py
@@ -71,18 +71,11 @@ class QuantAvgPool2d(CustomOp):
             ho = compute_pool_output_dim(hi, k, s)
             wo = compute_pool_output_dim(wi, k, s)
             oshape = (n, ho, wo, c)
-            # implement tensor with correct shape
-            values = np.random.randn(*oshape).astype(np.float32)
             return helper.make_node(
-                "Constant",
+                "RandomNormal",
                 inputs=[],
                 outputs=[node.output[0]],
-                value=helper.make_tensor(
-                    name="const_tensor",
-                    data_type=TensorProto.FLOAT,
-                    dims=values.shape,
-                    vals=values.flatten().astype(float),
-                ),
+                shape=list(oshape),
             )
 
         else:

--- a/src/finn/custom_op/general/quantavgpool2d.py
+++ b/src/finn/custom_op/general/quantavgpool2d.py
@@ -94,7 +94,7 @@ class QuantAvgPool2d(CustomOp):
     def infer_node_datatype(self, model):
         node = self.onnx_node
         bw = self.get_nodeattr("obits")
-        if bw in [2, 4, 8, 16, 32]:
+        if bw in range(2, 33):
             if self.get_nodeattr("signed") == 0:
                 dtype = DataType["UINT%d" % bw]
             else:

--- a/src/finn/custom_op/general/trunc.py
+++ b/src/finn/custom_op/general/trunc.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2021 Xilinx, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of Xilinx nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import numpy as np
+import onnx.helper as helper
+
+from finn.core.datatype import DataType
+from finn.custom_op.base import CustomOp
+from finn.custom_op.general.quant import resolve_rounding_mode
+
+
+def trunc(inp_tensor, scale, zeropt, input_bit_width, output_bit_width, rounding_mode):
+    # Port of TruncIntQuant class from Brevitas: https://bit.ly/3wzIpTR
+
+    # Scaling
+    y = inp_tensor / scale
+    y = y + zeropt
+    # Rounding
+    y = np.round(y)
+    # Truncate
+    trunc_bit_width = input_bit_width - output_bit_width
+    trunc_scale = 2.0 ** trunc_bit_width
+    y = y / trunc_scale
+
+    # To int
+    rounding_fx = resolve_rounding_mode(rounding_mode)
+    y = rounding_fx(y)
+
+    # Rescale
+    y = y - zeropt
+    y = y * scale
+
+    return y
+
+
+class Trunc(CustomOp):
+    """Generic truncation operation for QONNX. Takes four inputs:
+    - input tensor to truncate
+    - the scale
+    - the zero-point
+    - the truncation bit-width
+
+    The output is a tensor of the same shape as the input tensor, with truncated
+    values.
+    """
+
+    def get_nodeattr_types(self):
+        return {
+            # The rounding mode, which is used for the trunc function
+            "rounding_mode": ("s", True, "FLOOR"),
+        }
+
+    def make_shape_compatible_op(self, model):
+        node = self.onnx_node
+        return helper.make_node("Identity", [node.input[0]], [node.output[0]])
+
+    def infer_node_datatype(self, model):
+        node = self.onnx_node
+        model.set_tensor_datatype(node.output[0], DataType["FLOAT32"])
+
+    def execute_node(self, context, graph):
+        node = self.onnx_node
+        # save inputs
+        inp_tensor = context[node.input[0]]
+        scale = context[node.input[1]]
+        zeropt = context[node.input[2]]
+        input_bit_width = context[node.input[3]]
+        output_bit_width = context[node.input[4]]
+        # save attributes
+        rounding_mode = self.get_nodeattr("rounding_mode")
+        # calculate output
+        ret = trunc(
+            inp_tensor, scale, zeropt, input_bit_width, output_bit_width, rounding_mode
+        )
+        # set context according to output name
+        context[node.output[0]] = ret
+
+    def verify_node(self):
+        pass

--- a/src/finn/transformation/bipolar_to_xnor.py
+++ b/src/finn/transformation/bipolar_to_xnor.py
@@ -53,8 +53,8 @@ class ConvertBipolarMatMulToXnorPopcount(Transformation):
                 mm_input = n.input[0]
                 mm_weight = n.input[1]
                 mm_output = n.output[0]
-                i_bp = model.get_tensor_datatype(mm_input) == DataType.BIPOLAR
-                w_bp = model.get_tensor_datatype(mm_weight) == DataType.BIPOLAR
+                i_bp = model.get_tensor_datatype(mm_input) == DataType["BIPOLAR"]
+                w_bp = model.get_tensor_datatype(mm_weight) == DataType["BIPOLAR"]
                 if i_bp and w_bp:
                     # find producing threshold node and adjust output to binary
                     def find_prod_mt(x):
@@ -69,7 +69,7 @@ class ConvertBipolarMatMulToXnorPopcount(Transformation):
                     if len(mt_chain) == 0:
                         if mm_input == graph.input[0].name:
                             # change input datatype to BINARY
-                            model.set_tensor_datatype(mm_input, DataType.BINARY)
+                            model.set_tensor_datatype(mm_input, DataType["BINARY"])
                             graph_modified = True
                             warnings.warn(
                                 """IMPORTANT: Changing graph input DataType
@@ -100,7 +100,7 @@ class ConvertBipolarMatMulToXnorPopcount(Transformation):
                         mt_inst.set_nodeattr("out_dtype", "BINARY")
                         mt_inst.set_nodeattr("out_scale", 1.0)
                         mt_inst.set_nodeattr("out_bias", 0.0)
-                        model.set_tensor_datatype(mm_input, DataType.BINARY)
+                        model.set_tensor_datatype(mm_input, DataType["BINARY"])
                     # change node type and domain
                     n.op_type = "XnorPopcountMatMul"
                     n.domain = "finn.custom_op.general"
@@ -109,14 +109,14 @@ class ConvertBipolarMatMulToXnorPopcount(Transformation):
                     # extract vector length (common matrix dim)
                     K = Wbin.shape[0]
                     model.set_initializer(mm_weight, Wbin)
-                    model.set_tensor_datatype(mm_weight, DataType.BINARY)
+                    model.set_tensor_datatype(mm_weight, DataType["BINARY"])
                     # make new output node with correct shape
                     mm_out_shape = model.get_tensor_shape(mm_output)
                     xnorpcout = oh.make_tensor_value_info(
                         model.make_new_valueinfo_name(), TensorProto.FLOAT, mm_out_shape
                     )
                     n.output[0] = xnorpcout.name
-                    model.set_tensor_datatype(xnorpcout.name, DataType.UINT32)
+                    model.set_tensor_datatype(xnorpcout.name, DataType["UINT32"])
                     # add mul-add nodes to produce correct dot product result
                     # need to derive P-N from P and K = P+N
                     # so we need 2*P-K

--- a/src/finn/transformation/change_3d_tensors_to_4d.py
+++ b/src/finn/transformation/change_3d_tensors_to_4d.py
@@ -56,6 +56,12 @@ def _find_invalid_nodes(model):
         "Transpose",
         "LogSoftmax",
         "ArgMax",
+        "Div",
+        "TopK",
+        "MatMul",
+        "Flatten",
+        "Reshape",
+        "MaxPool",
     ]
     invalid_nodes = []
     for n in model.graph.node:
@@ -96,7 +102,7 @@ class Change3DTo4DTensors(Transformation):
         model = model.transform(RemoveUnusedTensors())
 
         # This list contains all nodes with initializers that need to be converted
-        nodes_with_initializers = ["Mul", "Conv", "Add"]
+        nodes_with_initializers = ["Mul", "Conv", "Add", "Div", "Reshape"]
         # Obtain a list of initializer names (used to filter out only value infos)
         initializers_names = [x.name for x in model.graph.initializer]
 
@@ -118,8 +124,7 @@ class Change3DTo4DTensors(Transformation):
                 if x.name not in initializers_names
             },
         }
-        # Extract only initializers from Conv, Mul and Add nodes (which are the
-        # only ones relevant for conversion)
+        # Extract only initializers from nodes that are relevant for conversion
         all_tensors = {
             **all_tensors,
             **{
@@ -143,10 +148,11 @@ class Change3DTo4DTensors(Transformation):
         tensors_reduced_dimension = []
         for n in model.graph.node:
             node_op_type = n.op_type
+            input_shape = model.get_tensor_shape(n.input[0])
             # Find tensors that are the output of nodes that reduce the dimension
             if node_op_type == "ArgMax":
                 keep_dims = get_by_name(n.attribute, "keepdims", "name").i
-                if keep_dims == 0:
+                if len(input_shape) == 3 and keep_dims == 0:
                     node_out = n.output
                     for n_o in node_out:
                         tensors_reduced_dimension.append(n_o)
@@ -158,10 +164,10 @@ class Change3DTo4DTensors(Transformation):
                     len(perm) == 3
                 ):  # Meaning that the transpose operation was on a 3D tensor
                     perm.append(3)  # append 4th dimension
-            elif node_op_type == "ArgMax" or node_op_type == "LogSoftMax":
+            elif node_op_type in ["ArgMax", "LogSoftMax", "TopK", "Flatten"]:
                 axis = get_by_name(n.attribute, "axis", "name")
-                if axis.i == -1:
-                    axis.i = 2  # argmax is now on the second-to-last axis
+                if len(input_shape) == 3 and axis.i < 0:
+                    axis.i = 3 + axis.i  # count dimensions from the front
             elif node_op_type == "Conv":
                 dilations = get_by_name(n.attribute, "dilations", "name").ints
                 kernel_shape = get_by_name(n.attribute, "kernel_shape", "name").ints
@@ -171,6 +177,19 @@ class Change3DTo4DTensors(Transformation):
                     dilations.append(
                         1
                     )  # only equal dilation value along each spatial axis is supported
+                if len(kernel_shape) == 1:  # we must add another dimension to it
+                    kernel_shape.append(1)
+                if (
+                    len(pads) == 2
+                ):  # pads = [x1_begin, x1_end] --> [x1_begin, x2_begin, x1_end, x2_end]
+                    pads.insert(1, 0)
+                    pads.append(0)
+                if len(strides) == 1:  # strides = [stride_h, stride_w]
+                    strides.append(1)
+            elif node_op_type == "MaxPool":
+                kernel_shape = get_by_name(n.attribute, "kernel_shape", "name").ints
+                pads = get_by_name(n.attribute, "pads", "name").ints
+                strides = get_by_name(n.attribute, "strides", "name").ints
                 if len(kernel_shape) == 1:  # we must add another dimension to it
                     kernel_shape.append(1)
                 if (

--- a/src/finn/transformation/create_generic_partitions.py
+++ b/src/finn/transformation/create_generic_partitions.py
@@ -143,21 +143,11 @@ class PartitionFromLambda(Transformation):
 
             # remove redundant input and output value_info entries
             for i in p_in_vi:
-                # the tensor can be both an input and value_info, so we also have to
-                # ensure that the tensor is not a relevant value_info before removing
-                if (
-                    i in p_model.graph.value_info
-                    and p_model.find_producer(i.name) is None
-                ):
+                if i in p_model.graph.value_info:
                     p_model.graph.value_info.remove(i)
 
             for o in p_out_vi:
-                # the tensor can both an output and value_info, so we also have to
-                # ensure that the tensor is not a relevant value_info before removing
-                if (
-                    o in p_model.graph.value_info
-                    and p_model.find_consumers(o.name) is None
-                ):
+                if o in p_model.graph.value_info:
                     p_model.graph.value_info.remove(o)
 
             # save partition model

--- a/src/finn/transformation/create_generic_partitions.py
+++ b/src/finn/transformation/create_generic_partitions.py
@@ -131,13 +131,13 @@ class PartitionFromLambda(Transformation):
                 to_check = next_to_check
 
             # set p graph in/out to be p_in/p_out
-            for x in p_model.graph.input:
-                p_model.graph.input.remove(x)
+            while len(p_model.graph.input) > 0:
+                p_model.graph.input.pop()
             for i in p_in_vi:
                 p_model.graph.input.append(i)
 
-            for x in p_model.graph.output:
-                p_model.graph.output.remove(x)
+            while len(p_model.graph.output) > 0:
+                p_model.graph.output.pop()
             for o in p_out_vi:
                 p_model.graph.output.append(o)
 

--- a/src/finn/transformation/extract_conv_bias.py
+++ b/src/finn/transformation/extract_conv_bias.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2021, Xilinx
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of FINN nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import warnings
+from onnx import TensorProto, helper
+
+from finn.transformation.base import Transformation
+
+
+class ExtractBiasFromConv(Transformation):
+    """
+    Extracts the (optional) Bias from a Conv node and inserts it behind the
+    Conv node as an Add node.
+    """
+
+    def apply(self, model):
+        graph = model.graph
+        node_ind = 0
+        for n in graph.node:
+            node_ind += 1
+            if n.op_type == "Conv":
+                # Check if the node has a bias input
+                if len(n.input) > 2:
+                    # Extract bias
+                    bias = model.get_initializer(n.input[2])
+                    if bias is None:
+                        warnings.warn(
+                            f"Could not extract bias from Conv node {n}, "
+                            f"due to missing static initialization."
+                        )
+                        continue
+
+                    # Insert bias as Add node behind the Conv node
+                    out_shape = model.get_tensor_shape(n.output[0])
+                    # Reshape bias tensor
+                    add_shape = [1] * len(out_shape)
+                    # ToDo: this must change to "add_shape[-1] = bias.shape[0]" when
+                    #  the channels last layout comes around.
+                    add_shape[1] = bias.shape[0]
+                    model.set_initializer(n.input[2], bias.reshape(add_shape))
+
+                    act_add_tensor = helper.make_tensor_value_info(
+                        model.make_new_valueinfo_name(),
+                        TensorProto.FLOAT,
+                        out_shape,
+                    )
+                    graph.value_info.append(act_add_tensor)
+
+                    add_node = helper.make_node(
+                        "Add",
+                        [act_add_tensor.name, n.input[2]],
+                        [n.output[0]],
+                    )
+                    graph.node.insert(node_ind, add_node)
+
+                    # Repoint Conv output and remove bias tensor
+                    n.output[0] = act_add_tensor.name
+                    n.input.remove(n.input[2])
+
+                    return model, True
+
+        return model, False

--- a/src/finn/transformation/gemm_to_matmul.py
+++ b/src/finn/transformation/gemm_to_matmul.py
@@ -1,0 +1,217 @@
+# Copyright (c) 2021, Xilinx
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of FINN nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import numpy as np
+import warnings
+from onnx import TensorProto, helper
+
+from finn.core.datatype import DataType
+from finn.transformation.base import Transformation
+from finn.transformation.remove import RemoveIdentityOps
+from finn.util.basic import get_by_name
+
+
+class GemmToMatMul(Transformation):
+    """
+    Converts Gemm nodes into a MatMul and an Add node.
+    This transformation is built to support version 9 of the Gemm node, as
+    documented here: https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Gemm-9
+    However, earlier and later versions of the node are likely to work as well.
+    Explicitly not supported is the optionality of input C in versions >=11 and
+    the broadcast attribute of versions <=6.
+    """
+
+    def apply(self, model):
+        graph = model.graph
+        node_ind = 0
+        for n in graph.node:
+            node_ind += 1
+            if n.op_type == "Gemm":
+                # Check for correct ONNX version
+                model_onnx_version = model.model.opset_import[0].version
+                if model_onnx_version != 9:
+                    warnings.warn(
+                        f"The GemmToMatMul transformation only offers explicit support "
+                        f"for version 9 of the Gemm node, but the ONNX version of the "
+                        f"supplied model is {model_onnx_version}. "
+                        f"Thus the transformation may fail or "
+                        f"return incomplete results."
+                    )
+                running_node_index = node_ind
+                # Transpose A?
+                transA = get_by_name(n.attribute, "transA")
+                if transA is not None and transA.i:
+                    # Insert transpose node
+                    shape = model.get_tensor_shape(n.input[0])
+                    if shape is not None:
+                        shape = tuple(reversed(shape))
+                    inp_trans_out = helper.make_tensor_value_info(
+                        model.make_new_valueinfo_name(),
+                        TensorProto.FLOAT,
+                        shape,
+                    )
+                    graph.value_info.append(inp_trans_out)
+                    inp_trans_node = helper.make_node(
+                        "Transpose", [n.input[0]], [inp_trans_out.name]
+                    )
+                    graph.node.insert(running_node_index, inp_trans_node)
+                    running_node_index += 1
+                    dt = model.get_tensor_datatype(n.input[0])
+                    if dt != DataType["FLOAT32"]:
+                        model.set_tensor_datatype(inp_trans_out.name, dt)
+
+                    n.input[0] = inp_trans_out.name
+
+                # Transpose B?
+                transB = get_by_name(n.attribute, "transB")
+                if transB is not None and transB.i:
+                    # Insert transpose node
+                    shape = model.get_tensor_shape(n.input[1])
+                    if shape is not None:
+                        shape = tuple(reversed(shape))
+                    inp_trans_out = helper.make_tensor_value_info(
+                        model.make_new_valueinfo_name(),
+                        TensorProto.FLOAT,
+                        shape,
+                    )
+                    graph.value_info.append(inp_trans_out)
+                    inp_trans_node = helper.make_node(
+                        "Transpose", [n.input[1]], [inp_trans_out.name]
+                    )
+                    graph.node.insert(running_node_index, inp_trans_node)
+                    running_node_index += 1
+                    # Copy over the datatype
+                    dt = model.get_tensor_datatype(n.input[1])
+                    if dt != DataType["FLOAT32"]:
+                        model.set_tensor_datatype(inp_trans_out.name, dt)
+
+                    n.input[1] = inp_trans_out.name
+
+                # Insert MatMul: A * B
+                matMul_node = helper.make_node(
+                    "MatMul", [n.input[0], n.input[1]], [n.output[0]]
+                )
+                graph.node.insert(running_node_index, matMul_node)
+                matMul_node = graph.node[running_node_index]
+                running_node_index += 1
+
+                # Insert Mul: (A*B) * alpha
+                alpha = get_by_name(n.attribute, "alpha")
+                if alpha is None:
+                    alpha = np.array(1.0)
+                else:
+                    alpha = np.array(alpha.f)
+                mul_tensor = helper.make_tensor_value_info(
+                    model.make_new_valueinfo_name(),
+                    TensorProto.FLOAT,
+                    None,
+                )
+                graph.value_info.append(mul_tensor)
+                model.set_initializer(mul_tensor.name, alpha)
+
+                A_shape = model.get_tensor_shape(n.input[0])
+                B_shape = model.get_tensor_shape(n.input[1])
+                if A_shape is not None and B_shape is not None:
+                    shape = [A_shape[0], B_shape[1]]
+                else:
+                    shape = None
+                act_mul_tensor = helper.make_tensor_value_info(
+                    model.make_new_valueinfo_name(),
+                    TensorProto.FLOAT,
+                    shape,
+                )
+                graph.value_info.append(act_mul_tensor)
+                mul_node = helper.make_node(
+                    "Mul",
+                    [act_mul_tensor.name, mul_tensor.name],
+                    [n.output[0]],
+                )
+                graph.node.insert(running_node_index, mul_node)
+                mul_node_main_branch = graph.node[running_node_index]
+                running_node_index += 1
+                matMul_node.output[0] = act_mul_tensor.name
+
+                # Other branch: Insert Mul: beta * C
+                beta = get_by_name(n.attribute, "beta")
+                if beta is None:
+                    beta = np.array(1.0)
+                else:
+                    beta = np.array(beta.f)
+                mul_tensor = helper.make_tensor_value_info(
+                    model.make_new_valueinfo_name(),
+                    TensorProto.FLOAT,
+                    None,
+                )
+                graph.value_info.append(mul_tensor)
+                model.set_initializer(mul_tensor.name, beta)
+
+                C_shape = model.get_tensor_shape(n.input[2])
+                act_mul_tensor = helper.make_tensor_value_info(
+                    model.make_new_valueinfo_name(),
+                    TensorProto.FLOAT,
+                    C_shape,
+                )
+                graph.value_info.append(act_mul_tensor)
+                mul_node = helper.make_node(
+                    "Mul",
+                    [n.input[2], mul_tensor.name],
+                    [act_mul_tensor.name],
+                )
+                graph.node.insert(running_node_index, mul_node)
+                running_node_index += 1
+                dt = model.get_tensor_datatype(n.input[2])
+                if dt != DataType["FLOAT32"]:
+                    model.set_tensor_datatype(act_mul_tensor.name, dt)
+                n.input[2] = act_mul_tensor.name
+
+                # Insert Add: ((A*B) * alpha) + (beta * C)
+                shape = model.get_tensor_shape(mul_node_main_branch.input[0])
+                act_add_tensor = helper.make_tensor_value_info(
+                    model.make_new_valueinfo_name(),
+                    TensorProto.FLOAT,
+                    shape,
+                )
+                graph.value_info.append(act_add_tensor)
+                mul_node_main_branch.output[0] = act_add_tensor.name
+                add_node = helper.make_node(
+                    "Add",
+                    [act_add_tensor.name, n.input[2]],
+                    [n.output[0]],
+                )
+
+                graph.node.insert(running_node_index, add_node)
+                running_node_index += 1
+
+                # Delete Gemm node
+                graph.node.remove(n)
+
+                # Remove potential unity multiplications from alpha and beta attributes
+                model = model.transform(RemoveIdentityOps())
+
+                return model, True
+
+        return model, False

--- a/src/finn/transformation/general.py
+++ b/src/finn/transformation/general.py
@@ -134,9 +134,13 @@ class GiveReadableTensorNames(Transformation):
                 if model.get_initializer(i) is not None:
                     model.rename_tensor(i, "%s_param%d" % (n.name, init_in_num))
                     init_in_num += 1
-        # give special names to the main model input and output
-        model.rename_tensor(model.graph.input[0].name, "global_in")
-        model.rename_tensor(model.graph.output[0].name, "global_out")
+        # give special names to the model inputs and outputs
+        for i, inp in enumerate(model.graph.input):
+            iname = "global_in" if i == 0 else "global_in_%d" % i
+            model.rename_tensor(inp.name, iname)
+        for i, outp in enumerate(model.graph.output):
+            oname = "global_out" if i == 0 else "global_out_%d" % i
+            model.rename_tensor(outp.name, oname)
         # return model_was_changed = False as single iteration is always enough
         return (model, False)
 

--- a/src/finn/transformation/infer_datatypes.py
+++ b/src/finn/transformation/infer_datatypes.py
@@ -29,7 +29,7 @@
 import finn.custom_op.registry as registry
 from finn.core.datatype import DataType
 from finn.transformation.base import Transformation
-from finn.util.basic import is_finn_op
+from finn.util.basic import get_by_name, is_finn_op
 
 
 def _infer_node_datatype(model, node):
@@ -41,7 +41,19 @@ def _infer_node_datatype(model, node):
         "Flatten",
         "Slice",
         "Gather",
+        "GatherElements",
+        "GatherND",
         "Identity",
+        "Expand",
+        "Flatten",
+        "MaxPool",
+        "GlobalMaxPool",
+        "Scatter",
+        "ScatterElements",
+        "ScatterND",
+        "Squeeze",
+        "Unsqueeze",
+        "Tile",
     ]
     idtypes = list(map(lambda x: model.get_tensor_datatype(x), node.input))
     odtypes = list(map(lambda x: model.get_tensor_datatype(x), node.output))
@@ -72,6 +84,16 @@ def _infer_node_datatype(model, node):
                 else:
                     odtype = DataType.UINT32
                 model.set_tensor_datatype(node.output[0], odtype)
+        elif node.op_type in ["Resize", "Upsample"]:
+            mode = get_by_name(node.attribute, "mode").s
+            if mode is None:
+                mode = "nearest"
+            else:
+                mode = mode.decode("UTF-8")
+            if mode == "nearest":
+                # set output dtype = input dtype
+                idtype = model.get_tensor_datatype(node.input[0])
+                model.set_tensor_datatype(node.output[0], idtype)
         elif node.op_type in dt_identity_optypes:
             # set output dtype = input dtype
             idtype = model.get_tensor_datatype(node.input[0])

--- a/src/finn/transformation/infer_datatypes.py
+++ b/src/finn/transformation/infer_datatypes.py
@@ -70,19 +70,19 @@ def _infer_node_datatype(model, node):
     else:
         if node.op_type == "Sign":
             # always produces bipolar outputs
-            model.set_tensor_datatype(node.output[0], DataType.BIPOLAR)
+            model.set_tensor_datatype(node.output[0], DataType["BIPOLAR"])
         elif node.op_type in ["MatMul", "Conv"]:
-            if len(list(filter(lambda x: x == DataType.FLOAT32, idtypes))) != 0:
+            if len(list(filter(lambda x: x == DataType["FLOAT32"], idtypes))) != 0:
                 # node has at least one float input, output is also float
-                model.set_tensor_datatype(node.output[0], DataType.FLOAT32)
+                model.set_tensor_datatype(node.output[0], DataType["FLOAT32"])
             else:
                 # TODO compute minimum / maximum result to minimize bitwidth
                 # use (u)int32 accumulators for now
                 has_signed_inp = len(list(filter(lambda x: x.signed(), idtypes))) != 0
                 if has_signed_inp:
-                    odtype = DataType.INT32
+                    odtype = DataType["INT32"]
                 else:
-                    odtype = DataType.UINT32
+                    odtype = DataType["UINT32"]
                 model.set_tensor_datatype(node.output[0], odtype)
         elif node.op_type in ["Resize", "Upsample"]:
             mode = get_by_name(node.attribute, "mode").s
@@ -103,11 +103,11 @@ def _infer_node_datatype(model, node):
             for o in node.output:
                 # check if output datatype is already set to a value != FLOAT32
                 odtype = model.get_tensor_datatype(o)
-                if odtype is not None and odtype != DataType.FLOAT32:
+                if odtype is not None and odtype != DataType["FLOAT32"]:
                     # don't change data type
                     model.set_tensor_datatype(o, odtype)
                 else:
-                    model.set_tensor_datatype(o, DataType.FLOAT32)
+                    model.set_tensor_datatype(o, DataType["FLOAT32"])
     # compare old and new output dtypes to see if anything changed
     new_odtypes = list(map(lambda x: model.get_tensor_datatype(x), node.output))
     graph_modified = new_odtypes != odtypes

--- a/src/finn/transformation/insert_topk.py
+++ b/src/finn/transformation/insert_topk.py
@@ -90,6 +90,6 @@ class InsertTopK(Transformation):
             # set quantization annotation for indices
             # minimal output dtype for TopK indices dependens on num. classes
             # assuming UINT32 is large enough for now (FINN has currently no
-            # DataType.INT64)
-            model.set_tensor_datatype(topk_indices.name, DataType.UINT32)
+            # DataType["INT64"])
+            model.set_tensor_datatype(topk_indices.name, DataType["UINT32"])
             return (model, True)

--- a/src/finn/transformation/make_input_chanlast.py
+++ b/src/finn/transformation/make_input_chanlast.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2021 Xilinx, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of Xilinx nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from onnx import helper as oh
+
+import finn.core.data_layout as data_layout
+from finn.transformation.base import Transformation
+
+
+class MakeInputChannelsLast(Transformation):
+    """For networks with an input using the NCx data layout, add a transpose node
+    at the beginning and mark the input as using NxC (channels-last)."""
+
+    def __init__(self):
+        super().__init__()
+
+    def apply(self, model):
+        graph_in_name = model.graph.input[0].name
+        graph_new_in_name = graph_in_name + "_transposed"
+        orig_ishape = model.get_tensor_shape(graph_in_name)
+        ndim = len(orig_ishape)
+        if ndim == 2:
+            # assume NC layout, no action needed
+            return (model, False)
+        elif ndim > 2:
+            orig_layout = model.get_tensor_layout(graph_in_name)
+            if orig_layout == data_layout.get_channels_last_layout_for_ndims(ndim):
+                # already marked as channels-last, no action needed
+                return (model, False)
+            else:
+                # determine channels-last shape and required permutation to
+                # go from channels-last to previous format
+                new_perm = list(range(ndim))
+                new_perm.remove(ndim - 1)
+                new_perm.insert(1, ndim - 1)
+                new_ishape = list(orig_ishape)
+                new_ishape.remove(orig_ishape[1])
+                new_ishape.append(orig_ishape[1])
+                # create and insert transpose node
+                t_trans_node = oh.make_node(
+                    "Transpose", [graph_in_name], [graph_new_in_name], perm=new_perm
+                )
+                model.graph.node.insert(0, t_trans_node)
+                # rewire all consumers of original input to transpose's output
+                consumers = model.find_consumers(graph_in_name)
+                for cons in consumers:
+                    if cons == t_trans_node:
+                        continue
+                    for i, ci in enumerate(cons.input):
+                        if ci == graph_in_name:
+                            cons.input[i] = graph_new_in_name
+                # set tensor shapes and layouts
+                model.set_tensor_shape(graph_in_name, new_ishape)
+                model.set_tensor_shape(graph_new_in_name, orig_ishape)
+                model.set_tensor_layout(
+                    graph_in_name, data_layout.get_channels_last_layout_for_ndims(ndim)
+                )
+                model.set_tensor_layout(
+                    graph_new_in_name,
+                    data_layout.get_channels_first_layout_for_ndims(ndim),
+                )
+                # single iteration is enough so return model_was_changed=False
+                return (model, False)

--- a/src/finn/transformation/remove.py
+++ b/src/finn/transformation/remove.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2020, Xilinx
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of FINN nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+import numpy as np
+
+from finn.transformation.base import Transformation
+from finn.transformation.infer_shapes import InferShapes
+from finn.util.basic import get_by_name
+
+
+def remove_node_and_rewire(model, node):
+    producer = model.find_producer(node.input[0])
+    if producer is not None:
+        # wire output tensor to
+        # output of producer node
+        producer.output[0] = node.output[0]
+    else:
+        # node is first in graph
+        successors = model.find_direct_successors(node)
+        assert successors is not None, "Whole graph is one node."
+        for succ in successors:
+            for i, s_inp in enumerate(succ.input):
+                if s_inp == node.output[0]:
+                    # rewire successor's input directly to graph input
+                    succ.input[i] = node.input[0]
+    # remove node
+    model.graph.node.remove(node)
+
+
+class RemoveIdentityOps(Transformation):
+    """Remove identity ops like Add/Sub with zero or Mul/Div with one. A tolerance
+    value (defaults to 1e-05) can be specified during init for the comparison
+    to zero/one."""
+
+    def __init__(self, atol=1e-05):
+        super().__init__()
+        self.atol = atol
+
+    def apply(self, model):
+        graph = model.graph
+        node_ind = 0
+        graph_modified = False
+        for n in graph.node:
+            node_ind += 1
+            if (
+                n.op_type in ["Add", "Sub"]
+                and not model.is_fork_node(n)
+                and not model.is_join_node(n)
+            ):
+                A = model.get_initializer(n.input[1])
+                if (
+                    A is not None
+                    and np.isclose(A, np.zeros_like(A), atol=self.atol).all()
+                ):
+                    remove_node_and_rewire(model, n)
+                    graph_modified = True
+                    break
+
+            elif (
+                n.op_type in ["Mul", "Div"]
+                and not model.is_fork_node(n)
+                and not model.is_join_node(n)
+            ):
+                A = model.get_initializer(n.input[1])
+                if (
+                    A is not None
+                    and np.isclose(A, np.ones_like(A), atol=self.atol).all()
+                ):
+                    remove_node_and_rewire(model, n)
+                    graph_modified = True
+                    break
+            elif (
+                n.op_type == "Pad"
+                and not model.is_fork_node(n)
+                and not model.is_join_node(n)
+            ):
+                pads = get_by_name(n.attribute, "pads")
+                pads = np.asarray(pads.ints)
+                if (pads == 0).all():
+                    remove_node_and_rewire(model, n)
+                    graph_modified = True
+                    break
+        model = model.transform(InferShapes())
+        return (model, graph_modified)

--- a/src/finn/util/basic.py
+++ b/src/finn/util/basic.py
@@ -71,7 +71,7 @@ alveo_default_platform["U280"] = "xilinx_u280_xdma_201920_3"
 
 def is_finn_op(op_type):
     "Return whether given op_type string is a FINN custom op"
-    return op_type.startswith("finn")
+    return op_type.startswith("finn") or op_type.startswith("qonnx.custom_op")
 
 
 def get_rtlsim_trace_depth():

--- a/src/finn/util/basic.py
+++ b/src/finn/util/basic.py
@@ -305,16 +305,22 @@ def gen_finn_dt_tensor(finn_dt, tensor_shape):
     """Generates random tensor in given shape and with given FINN DataType."""
     if type(tensor_shape) == list:
         tensor_shape = tuple(tensor_shape)
-    if finn_dt == DataType.BIPOLAR:
+    if finn_dt == DataType["BIPOLAR"]:
         tensor_values = np.random.randint(2, size=tensor_shape)
         tensor_values = 2 * tensor_values - 1
-    elif finn_dt == DataType.BINARY:
+    elif finn_dt == DataType["BINARY"]:
         tensor_values = np.random.randint(2, size=tensor_shape)
-    elif "INT" in finn_dt.name or finn_dt == DataType.TERNARY:
+    elif "INT" in finn_dt.name or finn_dt == DataType["TERNARY"]:
         tensor_values = np.random.randint(
             finn_dt.min(), high=finn_dt.max() + 1, size=tensor_shape
         )
-    elif finn_dt == DataType.FLOAT32:
+    elif "FIXED" in finn_dt.name:
+        int_dt = DataType["INT" + str(finn_dt.bitwidth())]
+        tensor_values = np.random.randint(
+            int_dt.min(), high=int_dt.max() + 1, size=tensor_shape
+        )
+        tensor_values = tensor_values * finn_dt.scale_factor()
+    elif finn_dt == DataType["FLOAT32"]:
         tensor_values = np.random.randn(*tensor_shape)
     else:
         raise ValueError(
@@ -360,13 +366,13 @@ def sanitize_quant_values(model, node_tensors, execution_context, check_values=F
     integers are indeed integers.
     """
 
-    for tensor in node_tensors:
-        dtype = model.get_tensor_datatype(tensor)
+    for tensor_name in node_tensors:
+        dtype = model.get_tensor_datatype(tensor_name)
         # floats don't need sanitization, skip to next
         # introduces less quicker runtime
-        if dtype == DataType.FLOAT32:
+        if dtype == DataType["FLOAT32"]:
             continue
-        current_values = execution_context[tensor]
+        current_values = execution_context[tensor_name]
         updated_values = current_values
         has_to_be_rounded = False
         # TODO: vectorize with numpy
@@ -379,7 +385,7 @@ def sanitize_quant_values(model, node_tensors, execution_context, check_values=F
             warnings.warn(
                 "The values of tensor {} can't be represented "
                 "with the set FINN datatype ({}), they will be rounded to match the "
-                "FINN datatype.".format(tensor, dtype)
+                "FINN datatype.".format(tensor_name, dtype.name)
             )
         # check if rounded values are not too far from original values
         max_error = max(np.abs(current_values - updated_values).flatten())
@@ -392,15 +398,15 @@ def sanitize_quant_values(model, node_tensors, execution_context, check_values=F
                         raise Exception(
                             """Values can't be represented with set
                                 finn datatype ({}) for input {}""".format(
-                                dtype, tensor
+                                dtype, tensor_name
                             )
                         )
-            execution_context[tensor] = updated_values
+            execution_context[tensor_name] = updated_values
         else:
             raise Exception(
                 """Rounding error is too high to match set FINN
             datatype ({}) for input {}""".format(
-                    dtype, tensor
+                    dtype, tensor_name
                 )
             )
     return execution_context

--- a/src/finn/util/data_packing.py
+++ b/src/finn/util/data_packing.py
@@ -281,11 +281,14 @@ def npy_to_rtlsim_input(input_file, input_dtype, pad_to_nbits, reverse_inner=Tru
         inp = np.load(input_file)
     else:
         raise Exception("input_file must be ndarray or filename for .npy")
-    packed_data = pack_innermost_dim_as_hex_string(
-        inp, input_dtype, pad_to_nbits, reverse_inner=reverse_inner
-    )
-    packed_data = packed_data.flatten()
-    packed_data = [int(x[2:], 16) for x in packed_data]
+    if inp.shape[-1] == 1 and input_dtype.is_integer():
+        packed_data = inp.flatten().astype(input_dtype.to_numpy_dt())
+    else:
+        packed_data = pack_innermost_dim_as_hex_string(
+            inp, input_dtype, pad_to_nbits, reverse_inner=reverse_inner
+        )
+        packed_data = packed_data.flatten()
+        packed_data = [int(x[2:], 16) for x in packed_data]
     return packed_data
 
 

--- a/src/finn/util/inference_cost.py
+++ b/src/finn/util/inference_cost.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2021 Xilinx, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of Xilinx nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import clize
+import json
+
+import finn.analysis.inference_cost as infca
+from finn.core.datatype import DataType
+from finn.core.modelwrapper import ModelWrapper
+from finn.transformation.fold_constants import FoldConstants
+from finn.transformation.general import (
+    GiveReadableTensorNames,
+    GiveUniqueNodeNames,
+    GiveUniqueParameterTensors,
+    RemoveStaticGraphInputs,
+    RemoveUnusedTensors,
+)
+from finn.transformation.infer_datatypes import InferDataTypes
+from finn.transformation.infer_shapes import InferShapes
+
+
+def compute_bops(inf_cost_dict):
+    total_bops = 0.0
+    for (k, v) in inf_cost_dict.items():
+        if k.startswith("op_mac"):
+            comps = k.split("_")
+            dt1 = DataType[comps[2]]
+            dt2 = DataType[comps[3]]
+            total_bops += dt1.bitwidth() * dt2.bitwidth() * v
+    return total_bops
+
+
+def compute_mem_bits(inf_cost_dict, filter_string="mem_w"):
+    total_mem_bits = 0.0
+    for (k, v) in inf_cost_dict.items():
+        if k.startswith(filter_string):
+            comps = k.split("_")
+            dt = DataType[comps[2]]
+            total_mem_bits += dt.bitwidth() * v
+    return total_mem_bits
+
+
+def inference_cost(
+    model_filename,
+    *,
+    output_json=None,
+    output_onnx=None,
+    preprocess=True,
+    discount_sparsity=True
+):
+    """Print the inference cost estimate metric for given ONNX model.
+    Supports the Quant op for weight/activation quantization.
+
+    :param model_filename: Filename for ONNX model
+    :param output_json: Optional JSON filename to save the inference cost dict
+    :param output_onnx: Optional ONNX filename to save the final model after any
+        preprocessing
+    :param preprocess: If set, run preprocessing steps such as shape inference,
+        datatype inference and constant folding. Strongly recommended.
+    :param discount_sparsity: If set, will discount op cost of MAC ops with a
+        constant zero weight, and the mem cost of constant zero weights.
+    """
+    print("Inference cost for " + model_filename)
+    model = ModelWrapper(model_filename)
+    if preprocess:
+        qnt_nodes = model.get_nodes_by_op_type("Quant")
+        for qnt_node in qnt_nodes:
+            qnt_node.domain = "finn.custom_op.general"
+        model = model.transform(InferShapes())
+        model = model.transform(GiveUniqueParameterTensors())
+        model = model.transform(InferDataTypes())
+        model = model.transform(FoldConstants())
+        model = model.transform(RemoveUnusedTensors())
+        model = model.transform(RemoveStaticGraphInputs())
+        model = model.transform(InferDataTypes())
+    model = model.transform(GiveUniqueNodeNames())
+    model = model.transform(GiveReadableTensorNames())
+    if output_onnx is not None:
+        model.save(output_onnx)
+    ret = model.analysis(lambda x: infca.inference_cost(x, discount_sparsity))
+    bops = compute_bops(ret)
+    mem_w_bits = compute_mem_bits(ret, "mem_w")
+    mem_o_bits = compute_mem_bits(ret, "mem_o")
+    ret["total_bops"] = bops
+    ret["total_mem_w_bits"] = mem_w_bits
+    ret["total_mem_o_bits"] = mem_o_bits
+
+    if "unsupported" in ret:
+        ret["unsupported"] = str(ret["unsupported"])
+    print(json.dumps(ret, sort_keys=True, indent=2))
+
+    if output_json is not None:
+        with open(output_json, "w") as f:
+            json.dump(ret, f, sort_keys=True, indent=2)
+
+
+def main():
+    clize.run(inference_cost)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/finn/util/platforms.py
+++ b/src/finn/util/platforms.py
@@ -1,0 +1,480 @@
+# Copyright (c) 2021, Xilinx
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of FINN nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import numpy as np
+from abc import abstractmethod
+
+# contains the amount of available FPGA resources for several
+# Xilinx platforms, as well as certain resource limit guidelines
+# for creating designs that can achieve timing closure
+
+# explicit value for res types/costs we don't care about
+DONT_CARE = -1
+# recommended resource limits from Xilinx for timing closure
+# respectively for LUT, FF, BRAM_18K, URAM, DSP res types
+DEFAULT_RES_LIMITS = np.array([0.7, 0.5, 0.80, 0.80, 0.80])
+DEFAULT_AVG_CONSTRAINTS = [((2, 3, 4), 0.7)]  #
+
+# resources required to instantiate certain infrastructure components
+# such as memory controllers and network interfaces
+DDR_RESOURCE_REQUIREMENTS = {
+    "LUT": 33256,
+    "FF": 44889,
+    "BRAM_18K": 199,
+    "URAM": 0,
+    "DSP": 3,
+}
+HBM_RESOURCE_REQUIREMENTS = {
+    "LUT": 10718,
+    "FF": 21793,
+    "BRAM_18K": 8,
+    "URAM": 0,
+    "DSP": 0,
+}
+
+# we assume use of VNx Alveo UDP stack
+# see: https://gitenterprise.xilinx.com/mruiznog/vitis_network_layer
+ETH_RESOURCE_REQUIREMENTS = {
+    "LUT": 35219,
+    "FF": 86269,
+    "BRAM_18K": 183,
+    "URAM": 0,
+    "DSP": 0,
+}
+
+
+class Platform:
+    def __init__(
+        self,
+        nslr=1,
+        ndevices=1,
+        sll_count=[],
+        hbm_slr=-1,
+        ddr_slr=[0],
+        eth_slr=0,
+        eth_gbps=0,
+        limits=DEFAULT_RES_LIMITS,
+        avg_constraints=DEFAULT_AVG_CONSTRAINTS,
+    ):
+        self.nslr = nslr
+        self.sll_count = sll_count
+        self.eth_slr = eth_slr
+        self.eth_gbps = eth_gbps
+        self.ndevices = ndevices
+        self.hbm_slr = hbm_slr
+        self.ddr_slr = ddr_slr
+        # limits must be a np.array either of
+        # the same shape as compute_resources
+        # or broadcastable to it
+        self.res_limits = limits
+        # list of tuples of the form ( tuple of resource positions to avg, limit )
+        self.avg_constraints = avg_constraints
+
+    @property
+    @abstractmethod
+    def compute_resources(self):
+        pass
+
+    @property
+    def guide_resources(self):
+        guide = []
+        # TODO: assert limits is of correct size
+        guide_res = (
+            np.tile(np.array(self.compute_resources), (self.ndevices, 1))
+        ).astype(int)
+        for i in range(self.nslr * self.ndevices):
+            # when in multi-FPGA mode, subtract cost of UDP connection from eth_slr
+            local_slr = i % self.nslr
+            if self.ndevices > 1 and local_slr == self.eth_slr:
+                guide_res[i][0] -= ETH_RESOURCE_REQUIREMENTS["LUT"]
+                guide_res[i][1] -= ETH_RESOURCE_REQUIREMENTS["FF"]
+                guide_res[i][2] -= ETH_RESOURCE_REQUIREMENTS["BRAM_18K"]
+                guide_res[i][3] -= ETH_RESOURCE_REQUIREMENTS["URAM"]
+                guide_res[i][4] -= ETH_RESOURCE_REQUIREMENTS["DSP"]
+            # subtract the cost of memory controllers
+            # if we have a choice between DDR and HBM, use HBM
+            if local_slr == self.hbm_slr:
+                guide_res[i][0] -= HBM_RESOURCE_REQUIREMENTS["LUT"]
+                guide_res[i][1] -= HBM_RESOURCE_REQUIREMENTS["FF"]
+                guide_res[i][2] -= HBM_RESOURCE_REQUIREMENTS["BRAM_18K"]
+                guide_res[i][3] -= HBM_RESOURCE_REQUIREMENTS["URAM"]
+                guide_res[i][4] -= HBM_RESOURCE_REQUIREMENTS["DSP"]
+            elif local_slr in self.ddr_slr:
+                guide_res[i][0] -= DDR_RESOURCE_REQUIREMENTS["LUT"]
+                guide_res[i][1] -= DDR_RESOURCE_REQUIREMENTS["FF"]
+                guide_res[i][2] -= DDR_RESOURCE_REQUIREMENTS["BRAM_18K"]
+                guide_res[i][3] -= DDR_RESOURCE_REQUIREMENTS["URAM"]
+                guide_res[i][4] -= DDR_RESOURCE_REQUIREMENTS["DSP"]
+            guide.append(list(guide_res[i]))
+        return guide
+
+    @property
+    def resource_count_dict(self):
+        res = dict()
+        for i in range(self.nslr * self.ndevices):
+            slr_res = dict()
+            slr_res["LUT"] = self.compute_resources[i % self.nslr][0]
+            slr_res["FF"] = self.compute_resources[i % self.nslr][1]
+            slr_res["BRAM_18K"] = self.compute_resources[i % self.nslr][2]
+            slr_res["URAM"] = self.compute_resources[i % self.nslr][3]
+            slr_res["DSP"] = self.compute_resources[i % self.nslr][4]
+            res["slr" + str(i)] = slr_res
+        return res
+
+    @property
+    def compute_connection_cost(self):
+        x = np.full((self.nslr * self.ndevices, self.nslr * self.ndevices), DONT_CARE)
+        # build connection cost matrix for one device's SLRs
+        xlocal = np.full((self.nslr, self.nslr), DONT_CARE)
+        for i in range(self.nslr):
+            for j in range(self.nslr):
+                if i == j:
+                    xlocal[i][j] = 0
+                elif abs(i - j) == 1:
+                    xlocal[i][j] = 1
+        # tile connection cost matrices for entire system
+        for i in range(self.ndevices):
+            x[
+                i * self.nslr : (i + 1) * self.nslr, i * self.nslr : (i + 1) * self.nslr
+            ] = xlocal
+        # set cost for ethernet connections, assuming daisy-chaining
+        for i in range(self.ndevices - 1):
+            x[i * self.nslr + self.eth_slr][(i + 1) * self.nslr + self.eth_slr] = 10
+            x[(i + 1) * self.nslr + self.eth_slr][i * self.nslr + self.eth_slr] = 10
+        return x
+
+    @property
+    def compute_connection_resource(self):
+        sll = np.full((self.nslr * self.ndevices, self.nslr * self.ndevices), 0)
+        # build connection resource matrix for one device's SLRs
+        slllocal = np.full((self.nslr, self.nslr), -1)
+        for i in range(self.nslr):
+            for j in range(self.nslr):
+                if i == j:
+                    # no SLL constraint when going from one SLR to itself
+                    slllocal[i][j] = -1
+                else:
+                    slllocal[i][j] = self.sll_count[i][j]
+        # tile connection cost matrices for entire system
+        for i in range(self.ndevices):
+            sll[
+                i * self.nslr : (i + 1) * self.nslr, i * self.nslr : (i + 1) * self.nslr
+            ] = slllocal
+        # set cost for ethernet connections, assuming daisy-chaining
+        eth = np.full((self.nslr * self.ndevices, self.nslr * self.ndevices), 0)
+        # no Eth throughput constraints from one SLR to itself
+        for i in range(self.ndevices * self.nslr):
+            eth[i][i] = -1
+        # apply symmetric ETH throughput constraints between the SLRs that have GTXes
+        for i in range(self.ndevices - 1):
+            eth[i * self.nslr + self.eth_slr][
+                (i + 1) * self.nslr + self.eth_slr
+            ] = self.eth_gbps * (10 ** 9)
+            eth[(i + 1) * self.nslr + self.eth_slr][
+                i * self.nslr + self.eth_slr
+            ] = self.eth_gbps * (10 ** 9)
+        # pack sll and eth info in one list-of-list-of-tuple structure
+        constraints = []
+        for i in range(self.ndevices * self.nslr):
+            constraints_line = []
+            for j in range(self.ndevices * self.nslr):
+                # make sure not to constrain both resources at the same time
+                # constrain for Eth throughput between SLRs on different devices
+                # constrain for SLLs between SLRs on same device
+                is_offchip = i // self.nslr != j // self.nslr
+                constraints_line.append(
+                    (-1 if is_offchip else sll[i][j], eth[i][j] if is_offchip else -1)
+                )
+            constraints.append(constraints_line)
+        return constraints
+
+    def map_device_to_slr(self, idx):
+        """Given a global SLR index, return device id and local slr index"""
+        assert idx <= self.nslr * self.ndevices
+        return (idx % self.nslr, idx // self.nslr)
+
+
+class Zynq7020_Platform(Platform):
+    def __init__(
+        self,
+        ndevices=1,
+        limits=DEFAULT_RES_LIMITS,
+        avg_constraints=DEFAULT_AVG_CONSTRAINTS,
+    ):
+        super(Zynq7020_Platform, self).__init__(
+            nslr=1,
+            ndevices=ndevices,
+            sll_count=[[0]],
+            ddr_slr=[],
+            eth_slr=0,
+            eth_gbps=1,
+            limits=limits,
+            avg_constraints=avg_constraints,
+        )
+
+    @property
+    def compute_resources(self):
+        return [[53200, 2 * 53200, 280, 0, 220] for i in range(1)]
+
+
+class ZU3EG_Platform(Platform):
+    def __init__(
+        self,
+        ndevices=1,
+        limits=DEFAULT_RES_LIMITS,
+        avg_constraints=DEFAULT_AVG_CONSTRAINTS,
+    ):
+        super(ZU3EG_Platform, self).__init__(
+            nslr=1,
+            ndevices=ndevices,
+            sll_count=[[0]],
+            ddr_slr=[],
+            eth_slr=0,
+            eth_gbps=1,
+            limits=limits,
+            avg_constraints=avg_constraints,
+        )
+
+    @property
+    def compute_resources(self):
+        return [[71000, 2 * 71000, 412, 0, 360] for i in range(1)]
+
+
+class ZU7EV_Platform(Platform):
+    def __init__(
+        self,
+        ndevices=1,
+        limits=DEFAULT_RES_LIMITS,
+        avg_constraints=DEFAULT_AVG_CONSTRAINTS,
+    ):
+        super(ZU7EV_Platform, self).__init__(
+            nslr=1,
+            ndevices=ndevices,
+            sll_count=[[0]],
+            ddr_slr=[],
+            eth_slr=0,
+            eth_gbps=1,
+            limits=limits,
+            avg_constraints=avg_constraints,
+        )
+
+    @property
+    def compute_resources(self):
+        return [[230000, 2 * 230000, 610, 92, 1728] for i in range(1)]
+
+
+class ZU9EG_Platform(Platform):
+    def __init__(
+        self,
+        ndevices=1,
+        limits=DEFAULT_RES_LIMITS,
+        avg_constraints=DEFAULT_AVG_CONSTRAINTS,
+    ):
+        super(ZU9EG_Platform, self).__init__(
+            nslr=1,
+            ndevices=ndevices,
+            sll_count=[[0]],
+            ddr_slr=[],
+            eth_slr=0,
+            eth_gbps=1,
+            limits=limits,
+            avg_constraints=avg_constraints,
+        )
+
+    @property
+    def compute_resources(self):
+        return [[274000, 2 * 274000, 1824, 0, 2520] for i in range(1)]
+
+
+class ZU28DR_Platform(Platform):
+    def __init__(
+        self,
+        ndevices=1,
+        limits=DEFAULT_RES_LIMITS,
+        avg_constraints=DEFAULT_AVG_CONSTRAINTS,
+    ):
+        super(ZU28DR_Platform, self).__init__(
+            nslr=1,
+            ndevices=ndevices,
+            sll_count=[[0]],
+            ddr_slr=[],
+            eth_slr=0,
+            eth_gbps=1,
+            limits=limits,
+            avg_constraints=avg_constraints,
+        )
+
+    @property
+    def compute_resources(self):
+        return [[425000, 2 * 425000, 2160, 80, 4272] for i in range(1)]
+
+
+class Alveo_NxU50_Platform(Platform):
+    def __init__(
+        self,
+        ndevices=1,
+        limits=DEFAULT_RES_LIMITS,
+        avg_constraints=DEFAULT_AVG_CONSTRAINTS,
+    ):
+        # according to Vivado: 23040 SLR0 <-> SLR1
+        sll_counts = [[0, 5000], [5000, 0]]
+        super(Alveo_NxU50_Platform, self).__init__(
+            nslr=2,
+            ndevices=ndevices,
+            sll_count=sll_counts,
+            ddr_slr=[],
+            hbm_slr=0,
+            eth_slr=1,
+            eth_gbps=100,
+            limits=limits,
+            avg_constraints=avg_constraints,
+        )
+
+    @property
+    def compute_resources(self):
+        # According to UG1120:
+        # U50 has identical resource counts on both SLRs
+        # return [[365000,2*365000,2*564, 304, 2580] for i in range(2)]
+        # we observe from Vivado that the resource counts are actually:
+        return [
+            [374400, 2 * 374400, 2 * 564, 304, 2592],
+            [368160, 2 * 368160, 2 * 564, 304, 2760],
+        ]
+
+
+class Alveo_NxU200_Platform(Platform):
+    def __init__(
+        self,
+        ndevices=1,
+        limits=DEFAULT_RES_LIMITS,
+        avg_constraints=DEFAULT_AVG_CONSTRAINTS,
+    ):
+        sll_counts = [[0, 5000, 0], [5000, 0, 5000], [0, 5000, 0]]
+        super(Alveo_NxU200_Platform, self).__init__(
+            nslr=3,
+            ndevices=ndevices,
+            sll_count=sll_counts,
+            ddr_slr=[0, 2],
+            eth_slr=2,
+            eth_gbps=100,
+            limits=limits,
+            avg_constraints=avg_constraints,
+        )
+
+    @property
+    def compute_resources(self):
+        # According to UG1120:
+        # return [[355000, 723000, 2*638, 320, 2265],
+        #        [160000, 331000, 2*326, 160, 1317],
+        #        [355000, 723000, 2*638, 320, 2265]]
+        # we observe from Vivado that the resource counts are actually:
+        return [
+            [385920, 2 * 385920, 2 * 714, 320, 2268],
+            [199680, 2 * 199680, 2 * 420, 160, 1320],
+            [385920, 2 * 385920, 2 * 714, 320, 2268],
+        ]
+
+
+class Alveo_NxU250_Platform(Platform):
+    def __init__(
+        self,
+        ndevices=1,
+        limits=DEFAULT_RES_LIMITS,
+        avg_constraints=DEFAULT_AVG_CONSTRAINTS,
+    ):
+        sll_counts = [
+            [0, 5000, 0, 0],
+            [5000, 0, 5000, 0],
+            [0, 5000, 0, 5000],
+            [0, 0, 5000, 0],
+        ]
+        super(Alveo_NxU250_Platform, self).__init__(
+            nslr=4,
+            ndevices=ndevices,
+            sll_count=sll_counts,
+            ddr_slr=[0, 1, 2, 3],
+            eth_slr=3,
+            eth_gbps=100,
+            limits=limits,
+            avg_constraints=avg_constraints,
+        )
+
+    @property
+    def compute_resources(self):
+        # According to UG1120:
+        # U250 has identical resource counts on all 4 SLRs:
+        # return [[345000,2*345000,2*500, 320, 2877] for i in range(4)]
+        # we observe from Vivado that the resource counts are actually:
+        return [[375000, 2 * 375000, 2 * 576, 320, 2880] for i in range(4)]
+
+
+class Alveo_NxU280_Platform(Platform):
+    def __init__(
+        self,
+        ndevices=1,
+        limits=DEFAULT_RES_LIMITS,
+        avg_constraints=DEFAULT_AVG_CONSTRAINTS,
+    ):
+        sll_counts = [[0, 5000, 0], [5000, 0, 5000], [0, 5000, 0]]
+        super(Alveo_NxU280_Platform, self).__init__(
+            nslr=3,
+            ndevices=ndevices,
+            sll_count=sll_counts,
+            ddr_slr=[0, 1],
+            hbm_slr=0,
+            eth_slr=2,
+            eth_gbps=100,
+            limits=limits,
+            avg_constraints=avg_constraints,
+        )
+
+    @property
+    def compute_resources(self):
+        # according to UG1120
+        # return [[369000, 746000, 2*507, 320, 2733],
+        #        [333000, 675000, 2*468, 320, 2877],
+        #        [367000, 729000, 2*512, 320, 2880]]
+        # observed from Vivado:
+        return [
+            [400800, 2 * 400800, 2 * 600, 320, 2736],
+            [382080, 2 * 382080, 2 * 576, 320, 2880],
+            [380640, 2 * 380640, 2 * 576, 320, 2880],
+        ]
+
+
+platforms = dict()
+platforms["U50"] = Alveo_NxU50_Platform
+platforms["U200"] = Alveo_NxU200_Platform
+platforms["U250"] = Alveo_NxU250_Platform
+platforms["U280"] = Alveo_NxU280_Platform
+platforms["Pynq-Z1"] = Zynq7020_Platform
+platforms["Pynq-Z2"] = Zynq7020_Platform
+platforms["Ultra96"] = ZU3EG_Platform
+platforms["ZCU104"] = ZU7EV_Platform
+platforms["ZCU102"] = ZU9EG_Platform
+platforms["ZCU111"] = ZU28DR_Platform

--- a/src/finn/util/pyverilator.py
+++ b/src/finn/util/pyverilator.py
@@ -107,6 +107,7 @@ def rtlsim_multi_io(sim, io_dict, num_out_values, trace_file="", sname="_V_V_"):
                 and _read_signal(sim, outp + sname + "TVALID") == 1
             ):
                 outputs = outputs + [_read_signal(sim, outp + sname + "TDATA")]
+                output_count += 1
             io_dict["outputs"][outp] = outputs
 
         toggle_clk(sim)
@@ -142,7 +143,10 @@ def rtlsim_multi_io(sim, io_dict, num_out_values, trace_file="", sname="_V_V_"):
 
 
 def pyverilate_stitched_ip(
-    model, read_internal_signals=True, disable_common_warnings=True
+    model,
+    read_internal_signals=True,
+    disable_common_warnings=True,
+    extra_verilator_args=[],
 ):
     """Given a model with stitched IP, return a PyVerilator sim object.
     Trace depth is also controllable, see get_rtlsim_trace_depth()
@@ -221,7 +225,7 @@ def pyverilate_stitched_ip(
         top_module_name=top_module_name,
         auto_eval=False,
         read_internal_signals=read_internal_signals,
-        extra_args=verilator_args,
+        extra_args=verilator_args + extra_verilator_args,
     )
     return sim
 

--- a/tests/core/test_basic_onnx_exec.py
+++ b/tests/core/test_basic_onnx_exec.py
@@ -81,7 +81,7 @@ def test_onnx_exec_internal_rounding():
 
     model = onnx.helper.make_model(graph, producer_name="mul-model")
     model = ModelWrapper(model)
-    idt = DataType.INT2
+    idt = DataType["INT2"]
     model.set_tensor_datatype("inp0", idt)
     model.set_tensor_datatype("inp1", idt)
     model.transform(InferShapes())

--- a/tests/core/test_datatypes.py
+++ b/tests/core/test_datatypes.py
@@ -32,52 +32,66 @@ from finn.core.datatype import DataType
 
 
 def test_datatypes():
-    assert DataType.BIPOLAR.allowed(-1)
-    assert DataType.BIPOLAR.allowed(0) is False
-    assert DataType.BINARY.allowed(-1) is False
-    assert DataType.BINARY.allowed(1)
-    assert DataType.TERNARY.allowed(2) is False
-    assert DataType.TERNARY.allowed(-1)
-    assert DataType.UINT2.allowed(2)
-    assert DataType.UINT2.allowed(10) is False
-    assert DataType.UINT3.allowed(5)
-    assert DataType.UINT3.allowed(-7) is False
-    assert DataType.UINT4.allowed(15)
-    assert DataType.UINT4.allowed(150) is False
-    assert DataType.UINT8.allowed(150)
-    assert DataType.UINT8.allowed(777) is False
-    assert DataType.UINT8.to_numpy_dt() == np.uint8
-    assert DataType.UINT16.allowed(14500)
-    assert DataType.UINT16.to_numpy_dt() == np.uint16
-    assert DataType.UINT16.allowed(-1) is False
-    assert DataType.UINT32.allowed(2 ** 10)
-    assert DataType.UINT32.allowed(-1) is False
-    assert DataType.UINT32.to_numpy_dt() == np.uint32
-    assert DataType.INT2.allowed(-1)
-    assert DataType.INT2.allowed(-10) is False
-    assert DataType.INT3.allowed(5) is False
-    assert DataType.INT3.allowed(-2)
-    assert DataType.INT4.allowed(15) is False
-    assert DataType.INT4.allowed(-5)
-    assert DataType.INT8.allowed(150) is False
-    assert DataType.INT8.allowed(-127)
-    assert DataType.INT8.to_numpy_dt() == np.int8
-    assert DataType.INT16.allowed(-1.04) is False
-    assert DataType.INT16.allowed(-7777)
-    assert DataType.INT16.to_numpy_dt() == np.int16
-    assert DataType.INT32.allowed(7.77) is False
-    assert DataType.INT32.allowed(-5)
-    assert DataType.INT32.allowed(5)
-    assert DataType.INT32.to_numpy_dt() == np.int32
-    assert DataType.BINARY.signed() is False
-    assert DataType.FLOAT32.signed()
-    assert DataType.BIPOLAR.signed()
-    assert DataType.TERNARY.signed()
+    assert DataType["BIPOLAR"].allowed(-1)
+    assert DataType["BIPOLAR"].allowed(0) is False
+    assert DataType["BINARY"].allowed(-1) is False
+    assert DataType["BINARY"].allowed(1)
+    assert DataType["TERNARY"].allowed(2) is False
+    assert DataType["TERNARY"].allowed(-1)
+    assert DataType["UINT2"].allowed(2)
+    assert DataType["UINT2"].allowed(10) is False
+    assert DataType["UINT3"].allowed(5)
+    assert DataType["UINT3"].allowed(-7) is False
+    assert DataType["UINT4"].allowed(15)
+    assert DataType["UINT4"].allowed(150) is False
+    assert DataType["UINT8"].allowed(150)
+    assert DataType["UINT8"].allowed(777) is False
+    assert DataType["UINT8"].to_numpy_dt() == np.uint8
+    assert DataType["UINT16"].allowed(14500)
+    assert DataType["UINT16"].to_numpy_dt() == np.uint16
+    assert DataType["UINT16"].allowed(-1) is False
+    assert DataType["UINT32"].allowed(2 ** 10)
+    assert DataType["UINT32"].allowed(-1) is False
+    assert DataType["UINT32"].to_numpy_dt() == np.uint32
+    assert DataType["INT2"].allowed(-1)
+    assert DataType["INT2"].allowed(-10) is False
+    assert DataType["INT3"].allowed(5) is False
+    assert DataType["INT3"].allowed(-2)
+    assert DataType["INT4"].allowed(15) is False
+    assert DataType["INT4"].allowed(-5)
+    assert DataType["INT8"].allowed(150) is False
+    assert DataType["INT8"].allowed(-127)
+    assert DataType["INT8"].to_numpy_dt() == np.int8
+    assert DataType["INT16"].allowed(-1.04) is False
+    assert DataType["INT16"].allowed(-7777)
+    assert DataType["INT16"].to_numpy_dt() == np.int16
+    assert DataType["INT32"].allowed(7.77) is False
+    assert DataType["INT32"].allowed(-5)
+    assert DataType["INT32"].allowed(5)
+    assert DataType["INT32"].to_numpy_dt() == np.int32
+    assert DataType["BINARY"].signed() is False
+    assert DataType["FLOAT32"].signed()
+    assert DataType["BIPOLAR"].signed()
+    assert DataType["TERNARY"].signed()
+
+
+def test_datatypes_fixedpoint():
+    assert DataType["FIXED<4,2>"].allowed(0.5)
+    assert DataType["FIXED<4,2>"].to_numpy_dt() == np.float32
+    assert DataType["FIXED<4,2>"].signed()
+    assert DataType["FIXED<4,2>"].scale_factor() == 0.25
+    assert DataType["FIXED<4,2>"].min() == -2.0
+    assert DataType["FIXED<4,2>"].max() == 1.75
+    assert DataType["FIXED<4,2>"].allowed(1.5)
+    assert DataType["FIXED<4,2>"].allowed(-1.5)
+    assert DataType["FIXED<4,2>"].allowed(1.8) is False
+    assert DataType["FIXED<4,2>"].is_integer() is False
+    assert DataType["FIXED<4,2>"].is_fixed_point() is True
 
 
 def test_smallest_possible():
-    assert DataType.get_smallest_possible(1) == DataType.BINARY
-    assert DataType.get_smallest_possible(1.1) == DataType.FLOAT32
-    assert DataType.get_smallest_possible(-1) == DataType.BIPOLAR
-    assert DataType.get_smallest_possible(-3) == DataType.INT3
-    assert DataType.get_smallest_possible(-3.2) == DataType.FLOAT32
+    assert DataType.get_smallest_possible(1) == DataType["BINARY"]
+    assert DataType.get_smallest_possible(1.1) == DataType["FLOAT32"]
+    assert DataType.get_smallest_possible(-1) == DataType["BIPOLAR"]
+    assert DataType.get_smallest_possible(-3) == DataType["INT3"]
+    assert DataType.get_smallest_possible(-3.2) == DataType["FLOAT32"]

--- a/tests/core/test_datatypes.py
+++ b/tests/core/test_datatypes.py
@@ -73,6 +73,7 @@ def test_datatypes():
     assert DataType["FLOAT32"].signed()
     assert DataType["BIPOLAR"].signed()
     assert DataType["TERNARY"].signed()
+    assert str(DataType["TERNARY"]) == "TERNARY"
 
 
 def test_datatypes_fixedpoint():
@@ -87,6 +88,7 @@ def test_datatypes_fixedpoint():
     assert DataType["FIXED<4,2>"].allowed(1.8) is False
     assert DataType["FIXED<4,2>"].is_integer() is False
     assert DataType["FIXED<4,2>"].is_fixed_point() is True
+    assert str(DataType["FIXED<4,2"]) == "FIXED<4,2>"
 
 
 def test_smallest_possible():

--- a/tests/core/test_modelwrapper.py
+++ b/tests/core/test_modelwrapper.py
@@ -31,6 +31,7 @@ import onnx
 from pkgutil import get_data
 
 import finn.core.data_layout as DataLayout
+from finn.core.datatype import DataType
 from finn.core.modelwrapper import ModelWrapper
 
 
@@ -166,3 +167,37 @@ def test_modelwrapper_detect_forks_n_joins():
     assert not model.is_join_node(Round_node)
     assert not model.is_join_node(Ceil_node)
     assert model.is_join_node(Add_node)
+
+
+def test_modelwrapper_setting_unsetting_datatypes():
+    # Set and unset some datatypes and check for expected return values
+    raw_m = get_data("finn.data", "onnx/mnist-conv/model.onnx")
+    model = ModelWrapper(raw_m)
+
+    test_node = model.graph.node[0]
+    test_tensor = test_node.output[0]
+
+    ret = model.get_tensor_datatype(test_tensor)
+    assert (
+        ret == DataType["FLOAT32"]
+    ), "Tensor datatype should be float32 for no initalization."
+
+    model.set_tensor_datatype(test_tensor, None)
+    ret = model.get_tensor_datatype(test_tensor)
+    assert ret == DataType["FLOAT32"], "An unset datatype should return float32."
+
+    model.set_tensor_datatype(test_tensor, DataType["INT3"])
+    ret = model.get_tensor_datatype(test_tensor)
+    assert ret == DataType["INT3"], "Tensor datatype should follow setting."
+
+    model.set_tensor_datatype(test_tensor, DataType["UINT4"])
+    ret = model.get_tensor_datatype(test_tensor)
+    assert ret == DataType["UINT4"], "Tensor datatype should follow setting."
+
+    model.set_tensor_datatype(test_tensor, None)
+    ret = model.get_tensor_datatype(test_tensor)
+    assert ret == DataType["FLOAT32"], "An unset datatype should return float32."
+
+    model.set_tensor_datatype(test_tensor, DataType["BIPOLAR"])
+    ret = model.get_tensor_datatype(test_tensor)
+    assert ret == DataType["BIPOLAR"], "Tensor datatype should follow setting."

--- a/tests/custom_op/test_im2col.py
+++ b/tests/custom_op/test_im2col.py
@@ -69,9 +69,9 @@ def execution_im2col(
     ]
 
     # test datatype inference
-    assert model.get_tensor_datatype("outp") is DataType.FLOAT32
+    assert model.get_tensor_datatype("outp") == DataType["FLOAT32"]
     model = model.transform(InferDataTypes())
-    assert model.get_tensor_datatype("outp") is idt
+    assert model.get_tensor_datatype("outp") == idt
 
     # prepare input data
     input_dict = {"inp": x}
@@ -112,7 +112,7 @@ def execution_im2col(
 # dilation_w  | 2    | 2    | 2    | 2
 def test_im2col_dilations():
     case_id = 0
-    idt = DataType.INT8
+    idt = DataType["INT8"]
     k_H = 2
     k_W = 2
     stride_h = 1
@@ -191,7 +191,7 @@ def test_im2col_dilations():
     )
 
     case_id = 1
-    idt = DataType.INT8
+    idt = DataType["INT8"]
     k_H = 2
     k_W = 2
     stride_h = 1
@@ -261,7 +261,7 @@ def test_im2col_dilations():
     )
 
     case_id = 2
-    idt = DataType.INT8
+    idt = DataType["INT8"]
     k_H = 2
     k_W = 2
     stride_h = 1
@@ -351,7 +351,7 @@ def test_im2col_dilations():
     )
 
     case_id = 3
-    idt = DataType.INT8
+    idt = DataType["INT8"]
     k_H = 2
     k_W = 2
     stride_h = 2
@@ -421,7 +421,7 @@ def test_im2col_dilations():
     )
 
     case_id = 4
-    idt = DataType.INT8
+    idt = DataType["INT8"]
     k_H = 3
     k_W = 3
     stride_h = 2
@@ -484,7 +484,7 @@ def test_im2col_dilations():
     )
 
     case_id = 5
-    idt = DataType.INT8
+    idt = DataType["INT8"]
     k_H = 2
     k_W = 1
     stride_h = 1
@@ -528,7 +528,7 @@ def test_im2col_dilations():
     )
 
     case_id = 6
-    idt = DataType.INT8
+    idt = DataType["INT8"]
     k_H = 2
     k_W = 1
     stride_h = 1
@@ -572,7 +572,7 @@ def test_im2col_dilations():
     )
 
     case_id = 7
-    idt = DataType.INT8
+    idt = DataType["INT8"]
     k_H = 2
     k_W = 1
     stride_h = 1
@@ -624,7 +624,7 @@ def test_im2col_dilations():
     )
 
     case_id = 8
-    idt = DataType.INT8
+    idt = DataType["INT8"]
     k_H = 2
     k_W = 1
     stride_h = 2
@@ -668,7 +668,7 @@ def test_im2col_dilations():
     )
 
     case_id = 9
-    idt = DataType.INT8
+    idt = DataType["INT8"]
     k_H = 3
     k_W = 1
     stride_h = 2
@@ -712,7 +712,7 @@ def test_im2col_dilations():
     )
 
     case_id = 10
-    idt = DataType.INT8
+    idt = DataType["INT8"]
     k_H = 2
     k_W = 2
     stride_h = 1
@@ -792,7 +792,7 @@ def test_im2col_dilations():
     )
 
     case_id = 11
-    idt = DataType.INT8
+    idt = DataType["INT8"]
     k_H = 2
     k_W = 1
     stride_h = 2
@@ -836,7 +836,7 @@ def test_im2col_dilations():
     )
 
     case_id = 12
-    idt = DataType.INT8
+    idt = DataType["INT8"]
     k_H = 2
     k_W = 2
     stride_h = 1
@@ -921,7 +921,7 @@ def test_im2col_dilations():
     )
 
     case_id = 13
-    idt = DataType.INT8
+    idt = DataType["INT8"]
     k_H = 2
     k_W = 3
     stride_h = 1
@@ -1012,7 +1012,7 @@ def test_im2col_dilations():
 def test_im2col():
     case_id = 0
     # bipolar inputs with following im2col parameters
-    idt = DataType.BIPOLAR
+    idt = DataType["BIPOLAR"]
     k_h = 2
     k_w = 2
     stride_h = 1
@@ -1110,7 +1110,7 @@ def test_im2col():
     )
 
     case_id = 1
-    idt = DataType.INT8
+    idt = DataType["INT8"]
     k_h = 2
     k_w = 2
     stride_h = 1
@@ -1174,7 +1174,7 @@ def test_im2col():
     )
 
     case_id = 2
-    idt = DataType.INT8
+    idt = DataType["INT8"]
     k_h = 2
     k_w = 2
     stride_h = 1
@@ -1258,7 +1258,7 @@ def test_im2col():
     )
 
     case_id = 3
-    idt = DataType.INT8
+    idt = DataType["INT8"]
     k_h = 2
     k_w = 2
     stride_h = 1
@@ -1325,7 +1325,7 @@ def test_im2col():
     )
 
     case_id = 4
-    idt = DataType.INT8
+    idt = DataType["INT8"]
     k_h = 3
     k_w = 2
     stride_h = 1
@@ -1386,7 +1386,7 @@ def test_im2col():
     )
 
     case_id = 5
-    idt = DataType.INT8
+    idt = DataType["INT8"]
     k_h = 3
     k_w = 2
     stride_h = 1
@@ -1467,7 +1467,7 @@ def test_im2col():
     )
 
     case_id = 6
-    idt = DataType.INT8
+    idt = DataType["INT8"]
     k_h = 3
     k_w = 1
     stride_h = 1
@@ -1506,7 +1506,7 @@ def test_im2col():
     )
 
     case_id = 7
-    idt = DataType.INT8
+    idt = DataType["INT8"]
     k_h = 3
     k_w = 1
     stride_h = 1
@@ -1553,7 +1553,7 @@ def test_im2col():
     )
 
     case_id = 8
-    idt = DataType.INT8
+    idt = DataType["INT8"]
     k_h = 3
     k_w = 1
     stride_h = 2
@@ -1593,7 +1593,7 @@ def test_im2col():
 
 
 def test_im2col_infer_shapes():
-    idt = DataType.BIPOLAR
+    idt = DataType["BIPOLAR"]
     k_h = 2
     k_w = 2
     stride_h = 1

--- a/tests/custom_op/test_im2col.py
+++ b/tests/custom_op/test_im2col.py
@@ -1637,16 +1637,6 @@ def test_im2col_infer_shapes():
         name="shape_graph",
         inputs=[inp],
         outputs=[outp],
-        value_info=[
-            helper.make_tensor_value_info(
-                "abs", TensorProto.FLOAT, [1, ifm_dim_h, ifm_dim_w, ifm_ch]
-            ),
-            helper.make_tensor_value_info(
-                "im2col",
-                TensorProto.FLOAT,
-                [1, ofm_dim_h, ofm_dim_w, k_h * k_w * ifm_ch],
-            ),
-        ],
     )
 
     model = helper.make_model(graph, producer_name="shape-model")
@@ -1655,7 +1645,15 @@ def test_im2col_infer_shapes():
     model.set_tensor_datatype("inp", idt)
 
     # test shape inference
-    model.transform(InferShapes())
+    assert model.get_tensor_shape("abs") is None
+    assert model.get_tensor_shape("im2col") is None
+    model = model.transform(InferShapes())
+    assert model.get_tensor_shape("abs") == [
+        1,
+        ifm_dim_h,
+        ifm_dim_w,
+        ifm_ch,
+    ]
     assert model.get_tensor_shape("im2col") == [
         1,
         ofm_dim_h,

--- a/tests/custom_op/test_xnorpopcountmatmul.py
+++ b/tests/custom_op/test_xnorpopcountmatmul.py
@@ -53,17 +53,17 @@ def test_xnorpopcountmatmul():
         helper.make_graph([node_def], "test_model", [x], [out], value_info=[W])
     )
     model = ModelWrapper(modelproto)
-    model.set_tensor_datatype("x", DataType.BINARY)
-    model.set_tensor_datatype("W", DataType.BINARY)
+    model.set_tensor_datatype("x", DataType["BINARY"])
+    model.set_tensor_datatype("W", DataType["BINARY"])
     W_data = np.asarray([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=np.float32)
     model.set_initializer("W", W_data)
     # test shape inference
     model = model.transform(InferShapes())
     assert model.get_tensor_shape("out") == [M, N]
     # test datatype inference
-    assert model.get_tensor_datatype("out") is DataType.FLOAT32
+    assert model.get_tensor_datatype("out") == DataType["FLOAT32"]
     model = model.transform(InferDataTypes())
-    assert model.get_tensor_datatype("out") is DataType.UINT32
+    assert model.get_tensor_datatype("out") == DataType["UINT32"]
     # test execution
     x_data = np.asarray([[1, 0, 0]], dtype=np.float32)
     inp_dict = {"x": x_data}

--- a/tests/transformation/test_4d_conversion.py
+++ b/tests/transformation/test_4d_conversion.py
@@ -20,7 +20,7 @@ def generate_random_input(model):
         input_node = model.graph.input[i]
         input_node_name = input_node.name
         input_node_shape = model.get_tensor_shape(input_node_name)
-        i_val = gen_finn_dt_tensor(DataType.FLOAT32, input_node_shape)
+        i_val = gen_finn_dt_tensor(DataType["FLOAT32"], input_node_shape)
         input_dict[input_node_name] = i_val
     return input_dict
 
@@ -31,7 +31,7 @@ def set_all_initializers(model):
         if len(n.input) > 1 and n.name != "TopK1":
             init_name = n.input[1]
             init_shape = model.get_tensor_shape(init_name)
-            init_val = gen_finn_dt_tensor(DataType.FLOAT32, init_shape)
+            init_val = gen_finn_dt_tensor(DataType["FLOAT32"], init_shape)
             model.set_initializer(init_name, init_val)
 
 

--- a/tests/transformation/test_batchnorm_to_affine.py
+++ b/tests/transformation/test_batchnorm_to_affine.py
@@ -64,7 +64,7 @@ def test_batchnorm_to_affine_shufflenet():
     op_types = list(map(lambda x: x.op_type, new_model.graph.node))
     assert "BatchNormalization" not in op_types
     produced = oxe.execute_onnx(new_model, input_dict)[oname]
-    assert np.isclose(expected, produced).all()
+    assert np.isclose(expected, produced, atol=1e-05).all()
     os.remove(export_onnx_path)
 
 

--- a/tests/transformation/test_batchnorm_to_affine.py
+++ b/tests/transformation/test_batchnorm_to_affine.py
@@ -56,7 +56,7 @@ def test_batchnorm_to_affine_shufflenet():
     iname = model.graph.input[0].name
     oname = model.graph.output[0].name
     ishape = model.get_tensor_shape(iname)
-    rand_inp = gen_finn_dt_tensor(DataType.INT8, ishape)
+    rand_inp = gen_finn_dt_tensor(DataType["INT8"], ishape)
     input_dict = {iname: rand_inp}
     expected = oxe.execute_onnx(model, input_dict)[oname]
     new_model = model.transform(BatchNormToAffine())

--- a/tests/transformation/test_conv_lowering.py
+++ b/tests/transformation/test_conv_lowering.py
@@ -70,7 +70,7 @@ def test_conv_lowering_convmnist():
 
 
 # input datatype
-@pytest.mark.parametrize("idt", [DataType.INT2, DataType.INT4])
+@pytest.mark.parametrize("idt", [DataType["INT2"], DataType["INT4"]])
 # kernel size
 @pytest.mark.parametrize("k_h", [2, 3])
 @pytest.mark.parametrize("k_w", [2, 3, 1])
@@ -101,7 +101,7 @@ def test_dws_reg_conv_lowering(
         padding[3] = 0
 
     wdt = idt
-    odt = DataType.INT32
+    odt = DataType["INT32"]
     ofm_ch = ifm_ch
     pad_h = padding[0] + padding[2]
     pad_w = padding[1] + padding[3]
@@ -190,7 +190,7 @@ def test_dws_reg_conv_lowering(
 
 
 # input datatype
-@pytest.mark.parametrize("idt", [DataType.INT2, DataType.INT4])
+@pytest.mark.parametrize("idt", [DataType["INT2"], DataType["INT4"]])
 # kernel size
 @pytest.mark.parametrize("k_h", [2])
 @pytest.mark.parametrize("k_w", [2])
@@ -227,7 +227,7 @@ def test_non_equal_padding(
     idt, k_h, k_w, ifm_dim_h, ifm_dim_w, ifm_ch, stride, padding
 ):
     wdt = idt
-    odt = DataType.INT32
+    odt = DataType["INT32"]
     ofm_ch = ifm_ch
     pad_h = padding[0] + padding[2]
     pad_w = padding[1] + padding[3]

--- a/tests/transformation/test_extend_partition.py
+++ b/tests/transformation/test_extend_partition.py
@@ -270,7 +270,7 @@ def create_model():
     )
     for i in range(0, 4):
         model.set_initializer("in2_conv" + str(i), conv_weights[i])
-        model.set_tensor_datatype("in2_conv" + str(i), DataType.INT4)
+        model.set_tensor_datatype("in2_conv" + str(i), DataType["INT4"])
 
     return model
 
@@ -319,4 +319,4 @@ def test_extend_partition(p, extend_id):
     # Check if FINN data_types are retained
     for n in model_extended.graph.node:
         if n.op_type == "Conv":
-            assert model_extended.get_tensor_datatype(n.input[1]) == DataType.INT4
+            assert model_extended.get_tensor_datatype(n.input[1]) == DataType["INT4"]

--- a/tests/transformation/test_infer_datatypes.py
+++ b/tests/transformation/test_infer_datatypes.py
@@ -46,13 +46,10 @@ def test_infer_datatypes():
     # this model has no DataType info, so add some DataType annotation
     # to make things a bit more exciting
     model.set_tensor_datatype("global_in", DataType.UINT8)
-    # manual non-float annotations on regular ONNX nodes won't disappear
-    # (InferDataTypes assumes they've been put there with good reason)
-    model.set_tensor_datatype("MaxPool_1_out0", DataType.INT4)
-    # MatMul with int weights + inputs will have int output datatype
-    model.set_tensor_datatype("MatMul_0_param0", DataType.UINT8)
+    # Conv with int weights + inputs will have int output datatype
+    model.set_tensor_datatype("Conv_0_param0", DataType.INT4)
     model = model.transform(InferDataTypes())
     assert model.get_tensor_datatype("global_in") == DataType.UINT8
-    assert model.get_tensor_datatype("Reshape_0_out0") == DataType.INT4
-    assert model.get_tensor_datatype("MatMul_0_out0") == DataType.INT32
+    assert model.get_tensor_datatype("Conv_0_out0") == DataType.INT32
+    assert model.get_tensor_datatype("Relu_0_out0") == DataType.FLOAT32
     assert model.get_tensor_datatype("global_out") == DataType.FLOAT32

--- a/tests/transformation/test_infer_datatypes.py
+++ b/tests/transformation/test_infer_datatypes.py
@@ -45,11 +45,11 @@ def test_infer_datatypes():
     model = model.transform(GiveReadableTensorNames())
     # this model has no DataType info, so add some DataType annotation
     # to make things a bit more exciting
-    model.set_tensor_datatype("global_in", DataType.UINT8)
+    model.set_tensor_datatype("global_in", DataType["UINT8"])
     # Conv with int weights + inputs will have int output datatype
-    model.set_tensor_datatype("Conv_0_param0", DataType.INT4)
+    model.set_tensor_datatype("Conv_0_param0", DataType["INT4"])
     model = model.transform(InferDataTypes())
-    assert model.get_tensor_datatype("global_in") == DataType.UINT8
-    assert model.get_tensor_datatype("Conv_0_out0") == DataType.INT32
-    assert model.get_tensor_datatype("Relu_0_out0") == DataType.FLOAT32
-    assert model.get_tensor_datatype("global_out") == DataType.FLOAT32
+    assert model.get_tensor_datatype("global_in") == DataType["UINT8"]
+    assert model.get_tensor_datatype("Conv_0_out0") == DataType["INT32"]
+    assert model.get_tensor_datatype("Relu_0_out0") == DataType["FLOAT32"]
+    assert model.get_tensor_datatype("global_out") == DataType["FLOAT32"]

--- a/tests/transformation/test_merge_onnx_models.py
+++ b/tests/transformation/test_merge_onnx_models.py
@@ -47,9 +47,9 @@ def test_merge_onnx_models():
     raw_m = get_data("finn.data", "onnx/mnist-conv/model.onnx")
     model1 = ModelWrapper(raw_m)
     # the input for model1 comes from a uint8 vector so we set the finn datatype
-    # of the input tensor to DataType.UINT8 to verify that the datatypes are correctly
-    # preserved in the transformed model
-    model1.set_tensor_datatype(model1.graph.input[0].name, DataType.UINT8)
+    # of the input tensor to DataType["UINT8"] to verify that the datatypes are
+    # correctly preserved in the transformed model
+    model1.set_tensor_datatype(model1.graph.input[0].name, DataType["UINT8"])
     model1 = model1.transform(InferShapes())
     model1 = model1.transform(GiveUniqueNodeNames())
     model1 = model1.transform(GiveReadableTensorNames())
@@ -122,4 +122,4 @@ def test_merge_onnx_models():
             assert sparsity == set_sparsity
 
     # check if finn datatype of graph.input[0] is still set to UINT8
-    assert model_transformed.get_tensor_datatype("global_in") == DataType.UINT8
+    assert model_transformed.get_tensor_datatype("global_in") == DataType["UINT8"]

--- a/tests/transformation/test_remove_identity_ops.py
+++ b/tests/transformation/test_remove_identity_ops.py
@@ -1,0 +1,95 @@
+import pytest
+
+import numpy as np
+from onnx import TensorProto, helper
+
+import finn.core.onnx_exec as oxe
+from finn.core.datatype import DataType
+from finn.core.modelwrapper import ModelWrapper
+from finn.transformation.infer_datatypes import InferDataTypes
+from finn.transformation.infer_shapes import InferShapes
+from finn.transformation.remove import RemoveIdentityOps
+from finn.util.basic import gen_finn_dt_tensor
+
+
+def insert_identity_op(model, op, as_first_node, approx):
+    if approx:
+        zero_val = 0.000001
+        one_val = 0.999999
+    else:
+        zero_val = 0.0
+        one_val = 1.0
+    if op in ["Add", "Sub"]:
+        val = np.asarray([zero_val], dtype=np.float32)
+    elif op in ["Mul", "Div"]:
+        val = np.asarray([one_val], dtype=np.float32)
+    else:
+        return
+
+    graph = model.graph
+    if as_first_node:
+        identity_node = helper.make_node(op, ["inp", "value"], ["ident_out"])
+        graph.node.insert(0, identity_node)
+        graph.node[1].input[0] = "ident_out"
+    else:
+        identity_node = helper.make_node(op, ["div_out", "value"], ["ident_out"])
+        graph.node.insert(3, identity_node)
+        graph.node[-1].input[0] = "ident_out"
+    model.set_initializer("value", val)
+
+    return model
+
+
+# identity operations to be inserted
+@pytest.mark.parametrize("op", ["Add", "Sub", "Mul", "Div"])
+@pytest.mark.parametrize("approx", [False, True])
+@pytest.mark.parametrize("as_first_node", [False, True])
+def test_remove_identity_ops(op, as_first_node, approx):
+
+    # set up onnx model
+    inp = helper.make_tensor_value_info("inp", TensorProto.FLOAT, [1, 4, 1, 1])
+    mul = helper.make_tensor_value_info("mul", TensorProto.FLOAT, [])
+    shape = helper.make_tensor_value_info("shape", TensorProto.FLOAT, [2])
+    div = helper.make_tensor_value_info("div", TensorProto.FLOAT, [])
+    matmul = helper.make_tensor_value_info("matmul", TensorProto.FLOAT, [4, 2])
+    outp = helper.make_tensor_value_info("outp", TensorProto.FLOAT, [1, 2])
+
+    mul_node = helper.make_node("Mul", ["inp", "mul"], ["mul_out"])
+    reshape_node = helper.make_node("Reshape", ["mul_out", "shape"], ["reshape_out"])
+    div_node = helper.make_node("Div", ["reshape_out", "div"], ["div_out"])
+    matmul_node = helper.make_node("MatMul", ["div_out", "matmul"], ["outp"])
+
+    graph = helper.make_graph(
+        nodes=[mul_node, reshape_node, div_node, matmul_node],
+        name="identity-graph",
+        inputs=[inp],
+        outputs=[outp],
+        value_info=[mul, shape, div, matmul],
+    )
+
+    model = helper.make_model(graph, producer_name="mulpastconv-model")
+    model = ModelWrapper(model)
+    inp_values = gen_finn_dt_tensor(DataType["INT2"], [1, 4, 1, 1])
+    mul_values = np.random.uniform(low=0.1, high=0.99, size=(1)).astype(np.float32)
+    shape_values = np.asarray([1, -1], dtype=np.int64)
+    div_values = np.random.uniform(low=0.1, high=0.99, size=(1)).astype(np.float32)
+    matmul_values = gen_finn_dt_tensor(DataType["INT2"], [4, 2])
+    model.set_initializer("mul", mul_values)
+    model.set_initializer("shape", shape_values)
+    model.set_initializer("div", div_values)
+    model.set_initializer("matmul", matmul_values)
+    insert_identity_op(model, op, as_first_node, approx)
+    model = model.transform(InferShapes())
+    model = model.transform(InferDataTypes())
+    idict = {"inp": inp_values}
+    odict = oxe.execute_onnx(model, idict)
+    out_before = odict["outp"]
+    num_of_nodes_before = len(model.graph.node)
+
+    model = model.transform(RemoveIdentityOps())
+    num_of_nodes_after = len(model.graph.node)
+    assert num_of_nodes_before - 1 == num_of_nodes_after
+
+    odict = oxe.execute_onnx(model, idict)
+    out_after = odict["outp"]
+    assert np.isclose(out_before, out_after, atol=1e-3).all()

--- a/tests/transformation/test_topk_insert.py
+++ b/tests/transformation/test_topk_insert.py
@@ -18,6 +18,7 @@ from finn.transformation.insert_topk import InsertTopK
 def test_topk_insert(k):
     raw_m = get_data("finn.data", "onnx/mnist-conv/model.onnx")
     model = ModelWrapper(raw_m)
+    model.model.opset_import[0].version = 11
 
     # do transformations (no topk)
     model = model.transform(InferShapes())

--- a/tests/util/test_data_packing.py
+++ b/tests/util/test_data_packing.py
@@ -39,52 +39,64 @@ from finn.util.data_packing import (
 
 
 def test_array2hexstring():
-    assert array2hexstring([1, 1, 1, 0], DataType.BINARY, 4) == "0xe"
-    assert array2hexstring([1, 1, 1, 0], DataType.BINARY, 8) == "0x0e"
-    assert array2hexstring([1, 1, 1, -1], DataType.BIPOLAR, 8) == "0x0e"
-    assert array2hexstring([3, 3, 3, 3], DataType.UINT2, 8) == "0xff"
-    assert array2hexstring([1, 3, 3, 1], DataType.UINT2, 8) == "0x7d"
-    assert array2hexstring([1, -1, 1, -1], DataType.INT2, 8) == "0x77"
-    assert array2hexstring([1, 1, 1, -1], DataType.INT4, 16) == "0x111f"
-    assert array2hexstring([-1], DataType.FLOAT32, 32) == "0xbf800000"
-    assert array2hexstring([17.125], DataType.FLOAT32, 32) == "0x41890000"
-    assert array2hexstring([1, 1, 0, 1], DataType.BINARY, 4, reverse=True) == "0xb"
-    assert array2hexstring([1, 1, 1, 0], DataType.BINARY, 8, reverse=True) == "0x07"
+    assert array2hexstring([1, 1, 1, 0], DataType["BINARY"], 4) == "0xe"
+    assert array2hexstring([1, 1, 1, 0], DataType["BINARY"], 8) == "0x0e"
+    assert array2hexstring([1, 1, 1, -1], DataType["BIPOLAR"], 8) == "0x0e"
+    assert array2hexstring([3, 3, 3, 3], DataType["UINT2"], 8) == "0xff"
+    assert array2hexstring([1, 3, 3, 1], DataType["UINT2"], 8) == "0x7d"
+    assert array2hexstring([1, -1, 1, -1], DataType["INT2"], 8) == "0x77"
+    assert array2hexstring([1, 1, 1, -1], DataType["INT4"], 16) == "0x111f"
+    assert array2hexstring([-1], DataType["FLOAT32"], 32) == "0xbf800000"
+    assert array2hexstring([17.125], DataType["FLOAT32"], 32) == "0x41890000"
+    assert array2hexstring([1, 1, 0, 1], DataType["BINARY"], 4, reverse=True) == "0xb"
+    assert array2hexstring([1, 1, 1, 0], DataType["BINARY"], 8, reverse=True) == "0x07"
+    # fixed point types
+    assert array2hexstring([17.125], DataType["FIXED<9,6>"], 12) == "0x089"
+    assert array2hexstring([-1.5], DataType["FIXED<4,2>"], 4) == "0xa"
 
 
 def test_pack_innermost_dim_as_hex_string():
     A = [[1, 1, 1, 0], [0, 1, 1, 0]]
     eA = np.asarray(["0x0e", "0x06"])
-    assert (pack_innermost_dim_as_hex_string(A, DataType.BINARY, 8) == eA).all()
+    assert (pack_innermost_dim_as_hex_string(A, DataType["BINARY"], 8) == eA).all()
     B = [[[3, 3], [3, 3]], [[1, 3], [3, 1]]]
     eB = np.asarray([["0x0f", "0x0f"], ["0x07", "0x0d"]])
-    assert (pack_innermost_dim_as_hex_string(B, DataType.UINT2, 8) == eB).all()
+    assert (pack_innermost_dim_as_hex_string(B, DataType["UINT2"], 8) == eB).all()
     C = [[[3, 3], [3, 3]], [[1, 3], [3, 1]]]
     eC = np.asarray([["0x0f", "0x0f"], ["0x0d", "0x07"]])
     assert (
-        pack_innermost_dim_as_hex_string(C, DataType.UINT2, 8, reverse_inner=True) == eC
+        pack_innermost_dim_as_hex_string(C, DataType["UINT2"], 8, reverse_inner=True)
+        == eC
     ).all()
 
 
 def test_finnpy_to_packed_bytearray():
     A = [[1, 1, 1, 0], [0, 1, 1, 0]]
     eA = np.asarray([[14], [6]], dtype=np.uint8)
-    assert (finnpy_to_packed_bytearray(A, DataType.BINARY) == eA).all()
+    assert (finnpy_to_packed_bytearray(A, DataType["BINARY"]) == eA).all()
     B = [[[3, 3], [3, 3]], [[1, 3], [3, 1]]]
     eB = np.asarray([[[15], [15]], [[7], [13]]], dtype=np.uint8)
-    assert (finnpy_to_packed_bytearray(B, DataType.UINT2) == eB).all()
+    assert (finnpy_to_packed_bytearray(B, DataType["UINT2"]) == eB).all()
     C = [1, 7, 2, 5]
     eC = np.asarray([23, 37], dtype=np.uint8)
-    assert (finnpy_to_packed_bytearray(C, DataType.UINT4) == eC).all()
+    assert (finnpy_to_packed_bytearray(C, DataType["UINT4"]) == eC).all()
     D = [[1, 7, 2, 5], [2, 5, 1, 7]]
     eD = np.asarray([[23, 37], [37, 23]], dtype=np.uint8)
-    assert (finnpy_to_packed_bytearray(D, DataType.UINT4) == eD).all()
+    assert (finnpy_to_packed_bytearray(D, DataType["UINT4"]) == eD).all()
     E = [[-4, 0, -4, -4]]
     eE = np.asarray(
         [[255, 255, 255, 252, 0, 0, 0, 0, 255, 255, 255, 252, 255, 255, 255, 252]],
         dtype=np.uint8,
     )
-    assert (finnpy_to_packed_bytearray(E, DataType.INT32) == eE).all()
+    assert (finnpy_to_packed_bytearray(E, DataType["INT32"]) == eE).all()
+    F = [[17.125, -2.0], [-3.5, 11.25]]
+    eF = np.asarray([[1, 19, 240], [3, 200, 90]], dtype=np.uint8)
+    assert (finnpy_to_packed_bytearray(F, DataType["FIXED<9,6>"]) == eF).all()
+    G = F
+    eG = np.asarray(
+        [[65, 137, 0, 0, 192, 0, 0, 0], [192, 96, 0, 0, 65, 52, 0, 0]], dtype=np.uint8
+    )
+    assert (finnpy_to_packed_bytearray(G, DataType["FLOAT32"]) == eG).all()
 
 
 def test_finnpy_to_packed_bytearray_fastmode_binary():
@@ -99,9 +111,9 @@ def test_finnpy_to_packed_bytearray_fastmode_binary():
         assert (ret_fast == ret_slow).all()
 
     for i in range(5):
-        test_fast_vs_slow_random(DataType.BIPOLAR, (1, 8))
-        test_fast_vs_slow_random(DataType.BINARY, (1, 16))
-        test_fast_vs_slow_random(DataType.BIPOLAR, (10, 600))
+        test_fast_vs_slow_random(DataType["BIPOLAR"], (1, 8))
+        test_fast_vs_slow_random(DataType["BINARY"], (1, 16))
+        test_fast_vs_slow_random(DataType["BIPOLAR"], (10, 600))
 
 
 def test_packed_bytearray_to_finnpy():
@@ -109,22 +121,22 @@ def test_packed_bytearray_to_finnpy():
     eA = [[1, 1, 1, 0], [0, 1, 1, 0]]
     eA = np.asarray(eA, dtype=np.float32)
     shapeA = eA.shape
-    assert (packed_bytearray_to_finnpy(A, DataType.BINARY, shapeA) == eA).all()
+    assert (packed_bytearray_to_finnpy(A, DataType["BINARY"], shapeA) == eA).all()
     B = np.asarray([[[15], [15]], [[7], [13]]], dtype=np.uint8)
     eB = [[[3, 3], [3, 3]], [[1, 3], [3, 1]]]
     eB = np.asarray(eB, dtype=np.float32)
     shapeB = eB.shape
-    assert (packed_bytearray_to_finnpy(B, DataType.UINT2, shapeB) == eB).all()
+    assert (packed_bytearray_to_finnpy(B, DataType["UINT2"], shapeB) == eB).all()
     C = np.asarray([23, 37], dtype=np.uint8)
     eC = [1, 7, 2, 5]
     eC = np.asarray(eC, dtype=np.float32)
     shapeC = eC.shape
-    assert (packed_bytearray_to_finnpy(C, DataType.UINT4, shapeC) == eC).all()
+    assert (packed_bytearray_to_finnpy(C, DataType["UINT4"], shapeC) == eC).all()
     D = np.asarray([[23, 37], [37, 23]], dtype=np.uint8)
     eD = [[1, 7, 2, 5], [2, 5, 1, 7]]
     eD = np.asarray(eD, dtype=np.float32)
     shapeD = eD.shape
-    assert (packed_bytearray_to_finnpy(D, DataType.UINT4, shapeD) == eD).all()
+    assert (packed_bytearray_to_finnpy(D, DataType["UINT4"], shapeD) == eD).all()
     E = np.asarray(
         [[255, 255, 255, 252, 0, 0, 0, 0, 255, 255, 255, 252, 255, 255, 255, 252]],
         dtype=np.uint8,
@@ -132,7 +144,7 @@ def test_packed_bytearray_to_finnpy():
     eE = [[-4, 0, -4, -4]]
     eE = np.asarray(eE, dtype=np.float32)
     shapeE = eE.shape
-    assert (packed_bytearray_to_finnpy(E, DataType.INT32, shapeE) == eE).all()
+    assert (packed_bytearray_to_finnpy(E, DataType["INT32"], shapeE) == eE).all()
     F = np.asarray(
         [[252, 255, 255, 255, 0, 0, 0, 0, 252, 255, 255, 255, 252, 255, 255, 255]],
         dtype=np.uint8,
@@ -142,7 +154,16 @@ def test_packed_bytearray_to_finnpy():
     shapeF = eF.shape
     assert (
         packed_bytearray_to_finnpy(
-            F, DataType.INT32, shapeF, reverse_inner=True, reverse_endian=True
+            F, DataType["INT32"], shapeF, reverse_inner=True, reverse_endian=True
         )
         == eF
     ).all()
+    G = np.asarray([[1, 19, 240], [3, 200, 90]], dtype=np.uint8)
+    eG = [[17.125, -2.0], [-3.5, 11.25]]
+    eG = np.asarray(eG, dtype=np.float32)
+    shapeG = eG.shape
+    assert (packed_bytearray_to_finnpy(G, DataType["FIXED<9,6>"], shapeG) == eG).all()
+    H = np.asarray(
+        [[65, 137, 0, 0, 192, 0, 0, 0], [192, 96, 0, 0, 65, 52, 0, 0]], dtype=np.uint8
+    )
+    assert (packed_bytearray_to_finnpy(H, DataType["FLOAT32"], shapeG) == eG).all()

--- a/tests/util/test_gen_finn_dt_tensor.py
+++ b/tests/util/test_gen_finn_dt_tensor.py
@@ -33,7 +33,7 @@ from finn.core.datatype import DataType
 def test_finn_tensor_generator():
     # bipolar
     shape_bp = [2, 2]
-    dt_bp = DataType.BIPOLAR
+    dt_bp = DataType["BIPOLAR"]
     tensor_bp = util.gen_finn_dt_tensor(dt_bp, shape_bp)
     # test shape
     for i in range(len(shape_bp)):
@@ -50,7 +50,7 @@ def test_finn_tensor_generator():
 
     # binary
     shape_b = [4, 2, 3]
-    dt_b = DataType.BINARY
+    dt_b = DataType["BINARY"]
     tensor_b = util.gen_finn_dt_tensor(dt_b, shape_b)
     # test shape
     for i in range(len(shape_b)):
@@ -67,7 +67,7 @@ def test_finn_tensor_generator():
 
     # ternary
     shape_t = [7, 1, 3, 1]
-    dt_t = DataType.TERNARY
+    dt_t = DataType["TERNARY"]
     tensor_t = util.gen_finn_dt_tensor(dt_t, shape_t)
     # test shape
     for i in range(len(shape_t)):
@@ -84,7 +84,7 @@ def test_finn_tensor_generator():
 
     # int2
     shape_int2 = [7, 4]
-    dt_int2 = DataType.INT2
+    dt_int2 = DataType["INT2"]
     tensor_int2 = util.gen_finn_dt_tensor(dt_int2, shape_int2)
     # test shape
     for i in range(len(shape_int2)):
@@ -103,3 +103,19 @@ def test_finn_tensor_generator():
             does not match the desired Data type"""
 
     # import pdb; pdb.set_trace()
+
+    # fixed point
+    dt_t = DataType["FIXED<9,6>"]
+    tensor_t = util.gen_finn_dt_tensor(dt_t, shape_t)
+    # test shape
+    for i in range(len(shape_t)):
+        assert (
+            shape_t[i] == tensor_t.shape[i]
+        ), """Shape of generated tensor
+            does not match the desired shape"""
+    # test if elements are FINN datatype
+    for value in tensor_t.flatten():
+        assert dt_t.allowed(
+            value
+        ), """Data type of generated tensor
+            does not match the desired Data type"""

--- a/tests/util/test_rtlsim2npy.py
+++ b/tests/util/test_rtlsim2npy.py
@@ -35,7 +35,7 @@ from finn.util.data_packing import unpack_innermost_dim_from_hex_string
 def test_unpack_innermost_dim_from_hex_string():
     # BINARY
     A = np.asarray(["0x0e", "0x06"])
-    dtype = DataType.BINARY
+    dtype = DataType["BINARY"]
     shape = (1, 2, 4)
     eA = [[1, 1, 1, 0], [0, 1, 1, 0]]
     A_unpacked = unpack_innermost_dim_from_hex_string(A, dtype, shape, 8)
@@ -50,7 +50,7 @@ def test_unpack_innermost_dim_from_hex_string():
 
     # UINT2
     B = np.asarray([["0x0f", "0x0f"], ["0x07", "0x0d"]])
-    dtype = DataType.UINT2
+    dtype = DataType["UINT2"]
     shape = (1, 2, 2, 2)
     eB = [[[3, 3], [3, 3]], [[1, 3], [3, 1]]]
     B_unpacked = unpack_innermost_dim_from_hex_string(B, dtype, shape, 8)
@@ -65,14 +65,14 @@ def test_unpack_innermost_dim_from_hex_string():
 
     # INT2
     C = np.asarray([["0x0f", "0x0f"], ["0x07", "0x0d"]])
-    dtype = DataType.INT2
+    dtype = DataType["INT2"]
     shape = (1, 2, 2, 2)
     eC = [[[-1, -1], [-1, -1]], [[1, -1], [-1, 1]]]
     C_unpacked = unpack_innermost_dim_from_hex_string(C, dtype, shape, 8)
     assert (C_unpacked == eC).all()
 
     C = np.asarray([["0x0f", "0x0f"], ["0x07", "0x0d"]])
-    dtype = DataType.INT2
+    dtype = DataType["INT2"]
     shape = (1, 2, 2, 2)
     eC = [[[-1, -1], [-1, -1]], [[-1, 1], [1, -1]]]
     C_unpacked = unpack_innermost_dim_from_hex_string(
@@ -82,7 +82,7 @@ def test_unpack_innermost_dim_from_hex_string():
 
     # INT4
     D = np.asarray(["0x0e", "0x06"])
-    dtype = DataType.INT4
+    dtype = DataType["INT4"]
     shape = (2, 1)
     eD = [[-2], [6]]
     D_unpacked = unpack_innermost_dim_from_hex_string(D, dtype, shape, 8)
@@ -95,7 +95,7 @@ def test_unpack_innermost_dim_from_hex_string():
 
     # INT32
     E = np.asarray(["0xffffffff", "0xfffffffe", "0x02", "0xffffffef"])
-    dtype = DataType.INT32
+    dtype = DataType["INT32"]
     shape = (1, 4, 1)
     eE = [[[-1], [-2], [2], [-17]]]
     E_unpacked = unpack_innermost_dim_from_hex_string(E, dtype, shape, 32)


### PR DESCRIPTION
Merged PRs:

* #36 Copied platforms from finn-experimental and made pre-commit conform
* #37 Added support for cost estimation for upsampling
* #41 Add support for Bipolar and Binary FINN datatype for Quant op.
* #42 #43 Updates to inference cost computation (Upsample and binary quantization)
* #44 chore: Add message to AssertionError
* #45 Various fixes from multi-headed net testing
* #46 Pull upstream changes into qonnx_quant_op
* #47 rtlsim improvements
* #48 Support and tests for unsetting FINN data types. 
* #50 DataType system refactoring and fixed-point types 
* #51 Faster&smaller shape inference 
* #52 QONNX ops and new general transformations 