### PR TITLE
[Fix] Make remote_exec and throughput_test compatible with PYNQ v2.7.0

### DIFF
--- a/src/finn/core/remote_exec.py
+++ b/src/finn/core/remote_exec.py
@@ -88,12 +88,12 @@ def remote_exec(model, execution_context):
         remote_cmd = "bash -ic 'bash alveo_run.sh execute %d' \"" % batchsize
     else:
         remote_cmd = (
-            "python3.6 driver.py --exec_mode=execute --batchsize={} "
+            "python3 driver.py --exec_mode=execute --batchsize={} "
             "--bitfile={} --inputfile=input.npy --outputfile=output.npy "
             '--platform={} "'
         ).format(batchsize, bitfile, platform)
     cmd = (
-        local_prefix + 'ssh {}@{} -p {} "cd {}/{}; ' + remote_prefix + remote_cmd
+        local_prefix + 'ssh {}@{} -p {} "source /etc/profile; cd {}/{}; ' + remote_prefix + remote_cmd
     ).format(pynq_username, pynq_ip, pynq_port, pynq_target_dir, deployment_folder)
     bash_command = ["/bin/bash", "-c", cmd]
     process_exec_accel = subprocess.Popen(bash_command, stdout=subprocess.PIPE)

--- a/src/finn/core/throughput_test.py
+++ b/src/finn/core/throughput_test.py
@@ -75,12 +75,12 @@ def throughput_test_remote(model, batchsize=1000, timeout=None):
         remote_cmd = "bash -ic 'bash alveo_run.sh throughput_test %d' \"" % batchsize
     else:
         remote_cmd = (
-            "python3.6 driver.py --exec_mode=throughput_test --batchsize={} "
+            "python3 driver.py --exec_mode=throughput_test --batchsize={} "
             "--bitfile={} --inputfile=input.npy --outputfile=output.npy "
             '--platform={} "'
         ).format(batchsize, bitfile, platform)
     cmd = (
-        local_prefix + 'ssh {}@{} -p {} "cd {}/{}; ' + remote_prefix + remote_cmd
+        local_prefix + 'ssh {}@{} -p {} "source /etc/profile; cd {}/{}; ' + remote_prefix + remote_cmd
     ).format(pynq_username, pynq_ip, pynq_port, pynq_target_dir, deployment_folder)
     bash_command = ["/bin/bash", "-c", cmd]
     process_throughput_test = subprocess.Popen(bash_command, stdout=subprocess.PIPE)


### PR DESCRIPTION
This PR makes remote_exec.py and throughput_test.py compatible with PYNQ v2.7.0
- finn-base tries to call python3.6 on PYNQ board when PYNQ board has only python3 or python3.8
- finn-base does not source the PYNQ venv and various configurations present in /etc/profile

This has been tested only on PYNQ-Z2 v2.7.0 SDCard image.