### PR TITLE
Disable casting float64 init to float32

### DIFF
--- a/src/finn/core/modelwrapper.py
+++ b/src/finn/core/modelwrapper.py
@@ -54,11 +54,10 @@ class ModelWrapper:
         onnx_model_proto can be either a ModelProto instance, or a string
         with the path to a stored .onnx file on disk, or serialized bytes.
 
-        - make_deepcopy: controls whether a deep copy of the ModelProto
+        make_deepcopy: controls whether a deep copy of the ModelProto
         is made internally.
-        - fix_float64 : DoubleToSingleFloat correction before applying any
-        transformations on this model.
-        """
+        fix_float64 : DoubleToSingleFloat correction before applying any
+        transformations on this model."""
         if isinstance(onnx_model_proto, str):
             assert os.path.isfile(
                 onnx_model_proto

--- a/src/finn/core/modelwrapper.py
+++ b/src/finn/core/modelwrapper.py
@@ -27,14 +27,15 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import copy
+import onnx
 import onnx.helper as oh
 import onnx.numpy_helper as np_helper
 import os
 import warnings
+from onnx import TensorProto
 
 import finn.util.basic as util
 import finn.util.onnx as onnxutil
-import onnx
 from finn.core.datatype import DataType
 from finn.transformation.double_to_single_float import DoubleToSingleFloat
 from finn.transformation.general import (
@@ -42,20 +43,21 @@ from finn.transformation.general import (
     RemoveUnusedTensors,
     SortGraph,
 )
-from onnx import TensorProto
 
 
 class ModelWrapper:
     """A wrapper around ONNX ModelProto that exposes some useful utility
     functions for graph manipulation and exploration."""
 
-    def __init__(self, onnx_model_proto, make_deepcopy=False):
+    def __init__(self, onnx_model_proto, make_deepcopy=False, fix_float64=False):
         """Creates a ModelWrapper instance.
         onnx_model_proto can be either a ModelProto instance, or a string
         with the path to a stored .onnx file on disk, or serialized bytes.
 
-        make_deepcopy: controls whether a deep copy of the ModelProto
+        - make_deepcopy: controls whether a deep copy of the ModelProto
         is made internally.
+        - fix_float64 : DoubleToSingleFloat correction before applying any
+        transformations on this model.
         """
         if isinstance(onnx_model_proto, str):
             assert os.path.isfile(
@@ -70,6 +72,7 @@ class ModelWrapper:
             else:
                 self._model_proto = onnx_model_proto
         self.temporary_fix_oldstyle_domain()
+        self.fix_float64 = fix_float64
 
     def temporary_fix_oldstyle_domain(self):
         found_oldstyle = False
@@ -119,20 +122,17 @@ class ModelWrapper:
         """Runs given anaylsis_fxn on this model and return resulting dict."""
         return analysis_fxn(self)
 
-    def transform(
-        self, transformation, make_deepcopy=True, cleanup=True, fix_float64=True
-    ):
+    def transform(self, transformation, make_deepcopy=True, cleanup=True):
         """Applies given Transformation repeatedly until no more changes can be made
         and returns a transformed ModelWrapper instance.
 
         - make_deepcopy : operates on a new (deep)copy of model.
-        - fix_float64 : DoubleToSingleFloat correction before starting
         - cleanup : execute cleanup transformations before returning
         """
         transformed_model = self
         if make_deepcopy:
             transformed_model = copy.deepcopy(self)
-        if fix_float64:
+        if self.fix_float64:
             (transformed_model, model_was_changed) = DoubleToSingleFloat().apply(
                 transformed_model
             )

--- a/src/finn/custom_op/general/bipolar_quant.py
+++ b/src/finn/custom_op/general/bipolar_quant.py
@@ -98,7 +98,7 @@ class BipolarQuant(CustomOp):
         # since numpy silently flattens 0d arrays to scalars
         # more: https://github.com/numpy/numpy/issues/13105
         if not isinstance(ret, np.ndarray):
-            ret = np.asarray(ret)
+            ret = np.asarray(ret, dtype=np.float32)
         # set context according to output name
         context[node.output[0]] = ret
 

--- a/src/finn/custom_op/general/debugmarker.py
+++ b/src/finn/custom_op/general/debugmarker.py
@@ -26,8 +26,9 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from finn.custom_op.base import CustomOp
 from onnx import helper
+
+from finn.custom_op.base import CustomOp
 
 
 class DebugMarker(CustomOp):

--- a/src/finn/custom_op/general/maxpoolnhwc.py
+++ b/src/finn/custom_op/general/maxpoolnhwc.py
@@ -27,10 +27,10 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import numpy as np
+from onnx import TensorProto, helper
 
 from finn.core.modelwrapper import ModelWrapper
 from finn.custom_op.base import CustomOp
-from onnx import TensorProto, helper
 
 
 def compute_pool_output_dim(ifm_dim, k, stride, pad=0, ceil_mode=0):

--- a/src/finn/custom_op/general/quant.py
+++ b/src/finn/custom_op/general/quant.py
@@ -234,7 +234,7 @@ class Quant(CustomOp):
         # since numpy silently flattens 0d arrays to scalars
         # more: https://github.com/numpy/numpy/issues/13105
         if not isinstance(ret, np.ndarray):
-            ret = np.asarray(ret)
+            ret = np.asarray(ret, dtype=np.float32)
         # set context according to output name
         context[node.output[0]] = ret
 

--- a/src/finn/custom_op/general/quantavgpool2d.py
+++ b/src/finn/custom_op/general/quantavgpool2d.py
@@ -28,11 +28,11 @@
 
 import numpy as np
 import onnxruntime as rt
+from onnx import TensorProto, helper
 
 from finn.core.datatype import DataType
 from finn.custom_op.base import CustomOp
 from finn.custom_op.general.maxpoolnhwc import compute_pool_output_dim
-from onnx import TensorProto, helper
 
 
 class QuantAvgPool2d(CustomOp):

--- a/src/finn/transformation/batchnorm_to_affine.py
+++ b/src/finn/transformation/batchnorm_to_affine.py
@@ -27,12 +27,12 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import numpy as np
+from onnx import TensorProto
+from onnx import helper as oh
 
 from finn.transformation.base import Transformation
 from finn.transformation.infer_shapes import InferShapes
 from finn.util.basic import get_by_name
-from onnx import TensorProto
-from onnx import helper as oh
 
 
 class BatchNormToAffine(Transformation):

--- a/src/finn/transformation/bipolar_to_xnor.py
+++ b/src/finn/transformation/bipolar_to_xnor.py
@@ -28,6 +28,8 @@
 
 import numpy as np
 import warnings
+from onnx import TensorProto
+from onnx import helper as oh
 
 from finn.core.datatype import DataType
 from finn.custom_op.registry import getCustomOp
@@ -35,8 +37,6 @@ from finn.transformation.base import Transformation
 from finn.transformation.infer_datatypes import InferDataTypes
 from finn.transformation.infer_shapes import InferShapes
 from finn.util.basic import get_by_name
-from onnx import TensorProto
-from onnx import helper as oh
 
 
 class ConvertBipolarMatMulToXnorPopcount(Transformation):

--- a/src/finn/transformation/change_datalayout.py
+++ b/src/finn/transformation/change_datalayout.py
@@ -26,10 +26,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from onnx import TensorProto, helper
+
 from finn.transformation.base import Transformation
 from finn.transformation.infer_shapes import InferShapes
 from finn.util.basic import get_by_name
-from onnx import TensorProto, helper
 
 
 class ChangeDataLayoutQuantAvgPool2d(Transformation):

--- a/src/finn/transformation/create_generic_partitions.py
+++ b/src/finn/transformation/create_generic_partitions.py
@@ -28,10 +28,10 @@
 
 import copy
 import pathlib
+from onnx import helper
 
 from finn.transformation.base import Transformation
 from finn.util.basic import make_build_dir
-from onnx import helper
 
 
 class PartitionFromLambda(Transformation):

--- a/src/finn/transformation/extract_conv_bias.py
+++ b/src/finn/transformation/extract_conv_bias.py
@@ -27,9 +27,9 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import warnings
+from onnx import TensorProto, helper
 
 from finn.transformation.base import Transformation
-from onnx import TensorProto, helper
 
 
 class ExtractBiasFromConv(Transformation):

--- a/src/finn/transformation/gemm_to_matmul.py
+++ b/src/finn/transformation/gemm_to_matmul.py
@@ -27,12 +27,12 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import numpy as np
 import warnings
+from onnx import TensorProto, helper
 
 from finn.core.datatype import DataType
 from finn.transformation.base import Transformation
 from finn.transformation.remove import RemoveIdentityOps
 from finn.util.basic import get_by_name
-from onnx import TensorProto, helper
 
 
 class GemmToMatMul(Transformation):

--- a/src/finn/transformation/insert_topk.py
+++ b/src/finn/transformation/insert_topk.py
@@ -27,11 +27,11 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import numpy as np
+from onnx import TensorProto
+from onnx import helper as oh
 
 from finn.core.datatype import DataType
 from finn.transformation.base import Transformation
-from onnx import TensorProto
-from onnx import helper as oh
 
 
 class InsertTopK(Transformation):

--- a/src/finn/transformation/lower_convs_to_matmul.py
+++ b/src/finn/transformation/lower_convs_to_matmul.py
@@ -27,10 +27,10 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import numpy as np
+from onnx import TensorProto, helper
 
 from finn.transformation.base import Transformation
 from finn.util.basic import get_by_name
-from onnx import TensorProto, helper
 
 
 def _auto_pad_to_explicit_padding(

--- a/src/finn/transformation/make_input_chanlast.py
+++ b/src/finn/transformation/make_input_chanlast.py
@@ -26,9 +26,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from onnx import helper as oh
+
 import finn.core.data_layout as data_layout
 from finn.transformation.base import Transformation
-from onnx import helper as oh
 
 
 class MakeInputChannelsLast(Transformation):

--- a/src/finn/transformation/merge_onnx_models.py
+++ b/src/finn/transformation/merge_onnx_models.py
@@ -27,6 +27,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import copy
 import warnings
+from onnx import helper
 
 from finn.core.modelwrapper import ModelWrapper
 from finn.transformation.base import Transformation
@@ -39,7 +40,6 @@ from finn.transformation.general import (
 from finn.transformation.infer_data_layouts import InferDataLayouts
 from finn.transformation.infer_datatypes import InferDataTypes
 from finn.transformation.infer_shapes import InferShapes
-from onnx import helper
 
 
 class MergeONNXModels(Transformation):

--- a/src/finn/transformation/remove.py
+++ b/src/finn/transformation/remove.py
@@ -101,7 +101,7 @@ class RemoveIdentityOps(Transformation):
                 and not model.is_join_node(n)
             ):
                 pads = get_by_name(n.attribute, "pads")
-                pads = np.asarray(pads.ints)
+                pads = np.asarray(pads.ints, dtype=np.int64)
                 if (pads == 0).all():
                     remove_node_and_rewire(model, n)
                     graph_modified = True

--- a/src/finn/util/onnx.py
+++ b/src/finn/util/onnx.py
@@ -27,9 +27,9 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import numpy as np
+import onnx
 
 import finn.core.data_layout as DataLayout
-import onnx
 
 
 def valueinfo_to_tensor(vi):

--- a/tests/analysis/test_is_linear.py
+++ b/tests/analysis/test_is_linear.py
@@ -27,11 +27,11 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import onnx.helper as oh
+from onnx import TensorProto
 
 import finn.analysis.topology as ta
 from finn.core.modelwrapper import ModelWrapper
 from finn.transformation.infer_shapes import InferShapes
-from onnx import TensorProto
 
 
 def test_is_linear_linear():

--- a/tests/analysis/test_topology_checks.py
+++ b/tests/analysis/test_topology_checks.py
@@ -27,12 +27,12 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import onnx.helper as oh
+from onnx import TensorProto
 from pkgutil import get_data
 
 import finn.analysis.topology as ta
 from finn.core.modelwrapper import ModelWrapper
 from finn.transformation.infer_shapes import InferShapes
-from onnx import TensorProto
 
 
 def test_all_tensors_f32():

--- a/tests/core/test_basic_onnx_exec.py
+++ b/tests/core/test_basic_onnx_exec.py
@@ -27,11 +27,11 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import numpy as np
+import onnx
 import onnx.numpy_helper as np_helper
 from pkgutil import get_data
 
 import finn.core.onnx_exec as oxe
-import onnx
 from finn.core.datatype import DataType
 from finn.core.modelwrapper import ModelWrapper
 from finn.transformation.infer_shapes import InferShapes

--- a/tests/core/test_custom_onnx_exec.py
+++ b/tests/core/test_custom_onnx_exec.py
@@ -27,10 +27,10 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import numpy as np
+from onnx import TensorProto, helper
 
 import finn.core.execute_custom_node as ex_cu_node
 from finn.custom_op.registry import getCustomOp
-from onnx import TensorProto, helper
 
 
 def test_execute_custom_node_multithreshold():

--- a/tests/core/test_mixed_onnx_exec.py
+++ b/tests/core/test_mixed_onnx_exec.py
@@ -27,11 +27,11 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import numpy as np
+from onnx import TensorProto, helper
 
 import finn.core.onnx_exec as oxe
 from finn.core.modelwrapper import ModelWrapper
 from finn.transformation.infer_shapes import InferShapes
-from onnx import TensorProto, helper
 
 
 def test_execute_mixed_model():

--- a/tests/core/test_modelwrapper.py
+++ b/tests/core/test_modelwrapper.py
@@ -27,10 +27,10 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import numpy as np
+import onnx
 from pkgutil import get_data
 
 import finn.core.data_layout as DataLayout
-import onnx
 from finn.core.datatype import DataType
 from finn.core.modelwrapper import ModelWrapper
 

--- a/tests/custom_op/test_im2col.py
+++ b/tests/custom_op/test_im2col.py
@@ -1,4 +1,5 @@
 import numpy as np
+from onnx import TensorProto, helper
 
 import finn.core.onnx_exec as oxe
 from finn.core.datatype import DataType
@@ -6,7 +7,6 @@ from finn.core.modelwrapper import ModelWrapper
 from finn.custom_op.general.im2col import compute_conv_output_dim
 from finn.transformation.infer_datatypes import InferDataTypes
 from finn.transformation.infer_shapes import InferShapes
-from onnx import TensorProto, helper
 
 
 def execution_im2col(

--- a/tests/custom_op/test_xnorpopcountmatmul.py
+++ b/tests/custom_op/test_xnorpopcountmatmul.py
@@ -28,13 +28,13 @@
 
 import numpy as np
 import onnx.helper as helper
+from onnx import TensorProto
 
 import finn.core.onnx_exec as oxe
 from finn.core.datatype import DataType
 from finn.core.modelwrapper import ModelWrapper
 from finn.transformation.infer_datatypes import InferDataTypes
 from finn.transformation.infer_shapes import InferShapes
-from onnx import TensorProto
 
 export_onnx_path = "test_xnorpopcountmatmul.onnx"
 

--- a/tests/transformation/test_4d_conversion.py
+++ b/tests/transformation/test_4d_conversion.py
@@ -1,9 +1,9 @@
 import pytest
 
 import numpy as np
+import onnx
 
 import finn.core.onnx_exec as oxe
-import onnx
 from finn.core.datatype import DataType
 from finn.core.modelwrapper import ModelWrapper
 from finn.transformation.change_3d_tensors_to_4d import Change3DTo4DTensors

--- a/tests/transformation/test_batchnorm_to_affine.py
+++ b/tests/transformation/test_batchnorm_to_affine.py
@@ -29,11 +29,11 @@
 import pytest
 
 import numpy as np
+import onnx
 import os
 import urllib.request as ureq
 
 import finn.core.onnx_exec as oxe
-import onnx
 from finn.core.datatype import DataType
 from finn.core.modelwrapper import ModelWrapper
 from finn.transformation.batchnorm_to_affine import BatchNormToAffine

--- a/tests/transformation/test_change_datalayout.py
+++ b/tests/transformation/test_change_datalayout.py
@@ -27,6 +27,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import pytest
 
+from onnx import TensorProto, helper
+
 import finn.core.data_layout as DataLayout
 import finn.core.onnx_exec as oxe
 from finn.core.datatype import DataType
@@ -38,7 +40,6 @@ from finn.transformation.infer_data_layouts import InferDataLayouts
 from finn.transformation.infer_datatypes import InferDataTypes
 from finn.transformation.infer_shapes import InferShapes
 from finn.util.basic import gen_finn_dt_tensor, get_by_name
-from onnx import TensorProto, helper
 
 
 # stride

--- a/tests/transformation/test_conv_lowering.py
+++ b/tests/transformation/test_conv_lowering.py
@@ -29,12 +29,13 @@
 import pytest
 
 import numpy as np
+import onnx
 import onnx.helper as oh
 import onnx.numpy_helper as np_helper
+from onnx import TensorProto
 from pkgutil import get_data
 
 import finn.core.onnx_exec as oxe
-import onnx
 from finn.core.datatype import DataType
 from finn.core.modelwrapper import ModelWrapper
 from finn.custom_op.general.im2col import compute_conv_output_dim
@@ -42,7 +43,6 @@ from finn.custom_op.registry import getCustomOp
 from finn.transformation.infer_shapes import InferShapes
 from finn.transformation.lower_convs_to_matmul import LowerConvsToMatMul
 from finn.util.basic import gen_finn_dt_tensor
-from onnx import TensorProto
 
 
 def test_conv_lowering_convmnist():

--- a/tests/transformation/test_extend_partition.py
+++ b/tests/transformation/test_extend_partition.py
@@ -29,6 +29,8 @@
 import pytest
 
 import numpy as np
+from onnx import TensorProto
+from onnx import helper as oh
 
 import finn.core.onnx_exec as oxe
 from finn.core.datatype import DataType
@@ -36,8 +38,6 @@ from finn.core.modelwrapper import ModelWrapper
 from finn.transformation.create_generic_partitions import PartitionFromDict
 from finn.transformation.extend_partition import ExtendPartition
 from finn.util.basic import gen_finn_dt_tensor
-from onnx import TensorProto
-from onnx import helper as oh
 
 
 def create_model():

--- a/tests/transformation/test_fold_constants.py
+++ b/tests/transformation/test_fold_constants.py
@@ -27,11 +27,11 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import numpy as np
+import onnx
 import onnx.numpy_helper as np_helper
 from pkgutil import get_data
 
 import finn.core.onnx_exec as oxe
-import onnx
 from finn.core.modelwrapper import ModelWrapper
 from finn.transformation.fold_constants import FoldConstants
 from finn.transformation.infer_shapes import InferShapes

--- a/tests/transformation/test_general_transformation.py
+++ b/tests/transformation/test_general_transformation.py
@@ -28,11 +28,11 @@
 
 import json
 import numpy as np
+import onnx
 import os
 from pkgutil import get_data
 
 import finn.core.onnx_exec as oxe
-import onnx
 from finn.core.modelwrapper import ModelWrapper
 from finn.custom_op.registry import getCustomOp
 from finn.transformation.general import (

--- a/tests/transformation/test_generic_partitioning.py
+++ b/tests/transformation/test_generic_partitioning.py
@@ -29,6 +29,7 @@
 import pytest
 
 import numpy as np
+from onnx import TensorProto, helper
 
 import finn.core.onnx_exec as oxe
 from finn.core.modelwrapper import ModelWrapper
@@ -36,7 +37,6 @@ from finn.custom_op.registry import getCustomOp
 from finn.transformation.create_generic_partitions import PartitionFromDict
 from finn.transformation.general import GiveReadableTensorNames, GiveUniqueNodeNames
 from finn.transformation.infer_shapes import InferShapes
-from onnx import TensorProto, helper
 
 
 # select example partitioning

--- a/tests/transformation/test_infer_shapes.py
+++ b/tests/transformation/test_infer_shapes.py
@@ -27,12 +27,12 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import numpy as np
+from onnx import TensorProto, helper
 from pkgutil import get_data
 
 import finn.util.basic as util
 from finn.core.modelwrapper import ModelWrapper
 from finn.transformation.infer_shapes import InferShapes
-from onnx import TensorProto, helper
 
 
 def test_infer_shapes():

--- a/tests/transformation/test_merge_onnx_models.py
+++ b/tests/transformation/test_merge_onnx_models.py
@@ -27,11 +27,12 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import numpy as np
+import onnx
 import onnx.numpy_helper as np_helper
+from onnx import TensorProto, helper
 from pkgutil import get_data
 
 import finn.core.onnx_exec as oxe
-import onnx
 from finn.core.datatype import DataType
 from finn.core.modelwrapper import ModelWrapper
 from finn.transformation.general import GiveReadableTensorNames, GiveUniqueNodeNames
@@ -39,7 +40,6 @@ from finn.transformation.infer_data_layouts import InferDataLayouts
 from finn.transformation.infer_datatypes import InferDataTypes
 from finn.transformation.infer_shapes import InferShapes
 from finn.transformation.merge_onnx_models import MergeONNXModels
-from onnx import TensorProto, helper
 
 
 def test_merge_onnx_models():

--- a/tests/transformation/test_remove_identity_ops.py
+++ b/tests/transformation/test_remove_identity_ops.py
@@ -1,6 +1,7 @@
 import pytest
 
 import numpy as np
+from onnx import TensorProto, helper
 
 import finn.core.onnx_exec as oxe
 from finn.core.datatype import DataType
@@ -9,7 +10,6 @@ from finn.transformation.infer_datatypes import InferDataTypes
 from finn.transformation.infer_shapes import InferShapes
 from finn.transformation.remove import RemoveIdentityOps
 from finn.util.basic import gen_finn_dt_tensor
-from onnx import TensorProto, helper
 
 
 def insert_identity_op(model, op, as_first_node, approx):

--- a/tests/transformation/test_renaming.py
+++ b/tests/transformation/test_renaming.py
@@ -29,13 +29,13 @@
 import pytest
 
 import numpy as np
+import onnx
 import onnx.numpy_helper as np_helper
 import os
 import urllib.request as ureq
 from pkgutil import get_data
 
 import finn.core.onnx_exec as oxe
-import onnx
 from finn.core.modelwrapper import ModelWrapper
 from finn.transformation.general import GiveReadableTensorNames, GiveUniqueNodeNames
 from finn.transformation.infer_shapes import InferShapes

--- a/tests/transformation/test_sort_graph.py
+++ b/tests/transformation/test_sort_graph.py
@@ -1,12 +1,12 @@
 import pytest
 
 import numpy as np
+from onnx import TensorProto, helper
 
 import finn.analysis.topology as ta
 from finn.core.modelwrapper import ModelWrapper
 from finn.transformation.general import SortGraph
 from finn.transformation.infer_shapes import InferShapes
-from onnx import TensorProto, helper
 
 
 def make_randomly_sorted_linear_model(num_of_nodes, seed=None):

--- a/tests/transformation/test_topk_insert.py
+++ b/tests/transformation/test_topk_insert.py
@@ -1,11 +1,11 @@
 import pytest
 
 import numpy as np
+import onnx
 import onnx.numpy_helper as nph
 from pkgutil import get_data
 
 import finn.core.onnx_exec as oxe
-import onnx
 from finn.core.modelwrapper import ModelWrapper
 from finn.transformation.fold_constants import FoldConstants
 from finn.transformation.general import GiveReadableTensorNames, GiveUniqueNodeNames


### PR DESCRIPTION
Remove the automatic `fix_float64=True` functionality in `ModelWrapper.transform`  which replaces float64 initializers with float32 ones - it will be an optional argument (default False) passed to the ModelWrapper contstructor instead.

This was a workaround for ONNX models that had invalid nodes according to previous versions of the standard, using two different datatypes for their inputs. This has been relaxed in recent versions of the standard and is no longer an issue for the most part.